### PR TITLE
no-jira: add logger to Monitor

### DIFF
--- a/lib/process_settings/monitor.rb
+++ b/lib/process_settings/monitor.rb
@@ -26,24 +26,21 @@ module ProcessSettings
 
       path = File.dirname(@file_path)
 
-      listener = file_change_notifier.to(path) do |modified, _added, _removed|
+      @listener = file_change_notifier.to(path) do |modified, _added, _removed|
         if modified.include?(@file_path)
           @logger.info("ProcessSettings::Monitor file #{@file_path} changed. Reloading.")
           load_untargeted_settings
         end
       end
 
-      listener.start
+      @listener.start
 
       load_untargeted_settings
+    end
 
-      Thread.new do
-        begin
-          sleep
-        rescue Exception => ex # using Exception base class since we're in a thread, we don't want any exceptions flying out... since they won't be logged
-          logger.fatal("ProcessSettings::Monitor thread exception! #{ex.class}: #{ex.messages}")
-        end
-      end.run
+    # stops listening for changes
+    def stop
+      @listener.stop
     end
 
     # Registers the given callback block to be called when settings change.

--- a/spec/lib/process_settings/monitor_spec.rb
+++ b/spec/lib/process_settings/monitor_spec.rb
@@ -18,6 +18,15 @@ describe ProcessSettings::Monitor do
 
   let(:logger) { Logger.new(STDERR).tap { |logger| logger.level = ::Logger::ERROR } }
 
+  # borrowed from https://github.com/guard/listen/blob/587f4a7edb75fac80faa3408c4513af715dace87/spec/spec_helper.rb
+  RSpec.configuration.before(:each) do
+    Listen::Internals::ThreadPool.stop
+  end
+
+  RSpec.configuration.after(:each) do
+    Listen::Internals::ThreadPool.stop
+  end
+
   describe "#initialize" do
     before do
       File.write(SETTINGS_PATH, SAMPLE_SETTINGS_YAML)


### PR DESCRIPTION
- Adds logger logger to instances of `ProcessSettings::Monitor`.
- Adds required logger config at the class level.
