### PR TITLE
Leaves original source file intact

### DIFF
--- a/lib/process_settings/replace_versioned_file.rb
+++ b/lib/process_settings/replace_versioned_file.rb
@@ -21,9 +21,7 @@ module ProcessSettings
         validate_source_version_is_not_older(source_file_path, destination_file_path)
 
         if source_version_is_newer?(source_file_path, destination_file_path)
-          FileUtils.mv(source_file_path, destination_file_path)
-        elsif source_file_path != destination_file_path # make sure we're not deleting destination file
-          FileUtils.rm_f(source_file_path) # clean up, remove left over file
+          FileUtils.cp(source_file_path, destination_file_path)
         end
       end
 
@@ -46,8 +44,6 @@ module ProcessSettings
           destination_version = ProcessSettings::TargetedSettings.from_file(destination_file_path, only_meta: true).version
 
           if source_version.to_f < destination_version.to_f
-            FileUtils.rm_f(source_file_path) # clean up, remove left over file
-
             raise SourceVersionOlderError,
                   "source file '#{source_file_path}' is version #{source_version}"\
                   " and destination file '#{destination_file_path}' is version #{destination_version}"

--- a/spec/lib/process_settings/replace_versioned_file_spec.rb
+++ b/spec/lib/process_settings/replace_versioned_file_spec.rb
@@ -32,8 +32,7 @@ describe ProcessSettings::ReplaceVersionedFile do
       it "should replace the file" do
         params = [combined_settings_v18, "spec/fixtures/production/combined_process_settings-xxx.yml"]
 
-        expect(FileUtils).to receive(:mv).with(*params)
-        expect(FileUtils).to_not receive(:rm_f)
+        expect(FileUtils).to receive(:cp).with(*params)
         described_class.replace_file_on_newer_file_version(*params)
       end
     end
@@ -42,8 +41,7 @@ describe ProcessSettings::ReplaceVersionedFile do
       it "raises FileDoesNotExistError" do
         params = ["spec/fixtures/production/combined_process_settings-xxx.yml", combined_settings_v18]
 
-        expect(FileUtils).to_not receive(:mv).with(*params)
-        expect(FileUtils).to_not receive(:rm_f)
+        expect(FileUtils).to_not receive(:cp).with(*params)
 
         expect { described_class.replace_file_on_newer_file_version(*params) }
           .to raise_error(ProcessSettings::ReplaceVersionedFile::FileDoesNotExistError,
@@ -55,8 +53,7 @@ describe ProcessSettings::ReplaceVersionedFile do
       it "should replace the file" do
         params = [combined_settings_v18, combined_settings_v16]
 
-        expect(FileUtils).to receive(:mv).with(*params)
-        expect(FileUtils).to_not receive(:rm_f)
+        expect(FileUtils).to receive(:cp).with(*params)
         described_class.replace_file_on_newer_file_version(*params)
       end
 
@@ -64,8 +61,7 @@ describe ProcessSettings::ReplaceVersionedFile do
         it "should replace the file" do
           params = [combined_settings_v18, combined_settings_v16_50]
 
-          expect(FileUtils).to receive(:mv).with(*params)
-          expect(FileUtils).to_not receive(:rm_f)
+          expect(FileUtils).to receive(:cp).with(*params)
           described_class.replace_file_on_newer_file_version(*params)
         end
       end
@@ -74,8 +70,7 @@ describe ProcessSettings::ReplaceVersionedFile do
         it "should replace the file" do
           params = combined_settings_v18_1, combined_settings_v16
 
-          expect(FileUtils).to receive(:mv).with(*params)
-          expect(FileUtils).to_not receive(:rm_f)
+          expect(FileUtils).to receive(:cp).with(*params)
           described_class.replace_file_on_newer_file_version(*params)
         end
       end
@@ -84,8 +79,7 @@ describe ProcessSettings::ReplaceVersionedFile do
         it "should replace the file" do
           params = combined_settings_v18_1, combined_settings_v16_50
 
-          expect(FileUtils).to receive(:mv).with(*params)
-          expect(FileUtils).to_not receive(:rm_f)
+          expect(FileUtils).to receive(:cp).with(*params)
           described_class.replace_file_on_newer_file_version(*params)
         end
       end
@@ -94,8 +88,7 @@ describe ProcessSettings::ReplaceVersionedFile do
         it "should replace the file" do
           params = combined_settings_v18_1, combined_settings_v16_0
 
-          expect(FileUtils).to receive(:mv).with(*params)
-          expect(FileUtils).to_not receive(:rm_f)
+          expect(FileUtils).to receive(:cp).with(*params)
           described_class.replace_file_on_newer_file_version(*params)
         end
       end
@@ -106,8 +99,7 @@ describe ProcessSettings::ReplaceVersionedFile do
         it "should not replace the file" do
           params = [combined_settings_v16, combined_settings_v16_0]
 
-          expect(FileUtils).to_not receive(:mv).with(*params)
-          expect(FileUtils).to receive(:rm_f)
+          expect(FileUtils).to_not receive(:cp).with(*params)
           described_class.replace_file_on_newer_file_version(*params)
         end
       end
@@ -116,8 +108,7 @@ describe ProcessSettings::ReplaceVersionedFile do
         it "should not replace the file" do
           params = combined_settings_v16_0, combined_settings_v16
 
-          expect(FileUtils).to_not receive(:mv).with(*params)
-          expect(FileUtils).to receive(:rm_f)
+          expect(FileUtils).to_not receive(:cp).with(*params)
           described_class.replace_file_on_newer_file_version(*params)
         end
       end
@@ -126,8 +117,7 @@ describe ProcessSettings::ReplaceVersionedFile do
         it "should not replace the file and raises SourceVersionOlderError" do
           params = [combined_settings_v16, combined_settings_v16_50]
 
-          expect(FileUtils).to_not receive(:mv).with(*params)
-          expect(FileUtils).to receive(:rm_f)
+          expect(FileUtils).to_not receive(:cp).with(*params)
 
           expect { described_class.replace_file_on_newer_file_version(*params) }
             .to raise_error(ProcessSettings::ReplaceVersionedFile::SourceVersionOlderError,
@@ -140,8 +130,7 @@ describe ProcessSettings::ReplaceVersionedFile do
         it "should replace the file" do
           params = combined_settings_v16_50, combined_settings_v16
 
-          expect(FileUtils).to receive(:mv).with(*params)
-          expect(FileUtils).to_not receive(:rm_f)
+          expect(FileUtils).to receive(:cp).with(*params)
           described_class.replace_file_on_newer_file_version(*params)
         end
       end
@@ -150,8 +139,7 @@ describe ProcessSettings::ReplaceVersionedFile do
         it "should not replace the file and raises SourceVersionOlderError" do
           params = combined_settings_v16_0, combined_settings_v16_50
 
-          expect(FileUtils).to_not receive(:mv).with(*params)
-          expect(FileUtils).to receive(:rm_f)
+          expect(FileUtils).to_not receive(:cp).with(*params)
 
           expect { described_class.replace_file_on_newer_file_version(*params) }
             .to raise_error(ProcessSettings::ReplaceVersionedFile::SourceVersionOlderError,
@@ -164,8 +152,7 @@ describe ProcessSettings::ReplaceVersionedFile do
         it "should replace the file" do
           params = combined_settings_v16_50, combined_settings_v16_0
 
-          expect(FileUtils).to receive(:mv).with(*params)
-          expect(FileUtils).to_not receive(:rm_f)
+          expect(FileUtils).to receive(:cp).with(*params)
           described_class.replace_file_on_newer_file_version(*params)
         end
       end
@@ -175,8 +162,7 @@ describe ProcessSettings::ReplaceVersionedFile do
       it "should not replace the file and raises SourceVersionOlderError" do
         params = [combined_settings_v16, combined_settings_v18]
 
-        expect(FileUtils).to_not receive(:mv).with(*params)
-        expect(FileUtils).to receive(:rm_f)
+        expect(FileUtils).to_not receive(:cp).with(*params)
 
         expect { described_class.replace_file_on_newer_file_version(*params) }
           .to raise_error(ProcessSettings::ReplaceVersionedFile::SourceVersionOlderError,
@@ -188,8 +174,7 @@ describe ProcessSettings::ReplaceVersionedFile do
         it "should not replace the file and raises SourceVersionOlderError" do
           params = [combined_settings_v16, combined_settings_v18_1]
 
-          expect(FileUtils).to_not receive(:mv).with(*params)
-          expect(FileUtils).to receive(:rm_f)
+          expect(FileUtils).to_not receive(:cp).with(*params)
 
           expect { described_class.replace_file_on_newer_file_version(*params) }
             .to raise_error(ProcessSettings::ReplaceVersionedFile::SourceVersionOlderError,
@@ -202,8 +187,7 @@ describe ProcessSettings::ReplaceVersionedFile do
         it "should not replace the file and raises SourceVersionOlderError" do
           params = combined_settings_v16_50, combined_settings_v18
 
-          expect(FileUtils).to_not receive(:mv).with(*params)
-          expect(FileUtils).to receive(:rm_f)
+          expect(FileUtils).to_not receive(:cp).with(*params)
 
           expect { described_class.replace_file_on_newer_file_version(*params) }
             .to raise_error(ProcessSettings::ReplaceVersionedFile::SourceVersionOlderError,
@@ -216,8 +200,7 @@ describe ProcessSettings::ReplaceVersionedFile do
         it "should not replace the file and raises SourceVersionOlderError" do
           params = combined_settings_v16_0, combined_settings_v18_1
 
-          expect(FileUtils).to_not receive(:mv).with(*params)
-          expect(FileUtils).to receive(:rm_f)
+          expect(FileUtils).to_not receive(:cp).with(*params)
 
           expect { described_class.replace_file_on_newer_file_version(*params) }
             .to raise_error(ProcessSettings::ReplaceVersionedFile::SourceVersionOlderError,
@@ -230,8 +213,7 @@ describe ProcessSettings::ReplaceVersionedFile do
         it "should not replace the file and raises SourceVersionOlderError" do
           params = combined_settings_v16_50, combined_settings_v18_1
 
-          expect(FileUtils).to_not receive(:mv).with(*params)
-          expect(FileUtils).to receive(:rm_f)
+          expect(FileUtils).to_not receive(:cp).with(*params)
 
           expect { described_class.replace_file_on_newer_file_version(*params) }
             .to raise_error(ProcessSettings::ReplaceVersionedFile::SourceVersionOlderError,


### PR DESCRIPTION
## Leave Original File Intact
"Also @juanfleal I don't think we're getting the etag benefits right now because you're deleting the file from -temp each time. Instead, if you leave it there, the s3 sync should be much faster because they can just check the etag to find that nothing has changed." - Colin Kelly
https://github.com/Invoca/invoca_process_settings/pull/16

### Summary of Changes
Does a file copy instead of a file move
No longer removes original file as a cleanup action

### Note 
Once merged we'll need to bump the version and push up to rubygems.org then s3_sync will need to be updated so that it uses this version.