### PR TITLE
fix process_settings_for_services to use settings:

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    process_settings (0.4.2)
+    process_settings (0.4.3)
       activesupport
       json
       listen (~> 3.0)
@@ -9,7 +9,7 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (6.0.2)
+    activesupport (6.0.2.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -27,15 +27,15 @@ GEM
       tins (~> 1.6)
     diff-lcs (1.3)
     docile (1.3.1)
-    ffi (1.11.3)
-    i18n (1.7.0)
+    ffi (1.12.2)
+    i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     method_source (0.9.0)
-    minitest (5.13.0)
+    minitest (5.14.0)
     parallel (1.12.1)
     parser (2.5.1.2)
       ast (~> 2.4.0)
@@ -46,7 +46,7 @@ GEM
     rainbow (3.0.0)
     rake (12.3.3)
     rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
+    rb-inotify (0.10.1)
       ffi (~> 1.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -86,7 +86,7 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tins (1.20.2)
-    tzinfo (1.2.5)
+    tzinfo (1.2.6)
       thread_safe (~> 0.1)
     unicode-display_width (1.4.0)
     zeitwerk (2.2.2)

--- a/bin/process_settings_for_services
+++ b/bin/process_settings_for_services
@@ -62,14 +62,14 @@ flat_services_yml_json_doc.each do |service, nodes|
       if (changed = node_targeted_process_settings_old != node_targeted_process_settings_new)
         node_old =  node_targeted_process_settings_old.map do |node_targeted_process_setting|
                       {
-                        'target'            => node_targeted_process_setting.target,
-                        "process_settings"  => node_targeted_process_setting.process_settings
+                        'target'    => node_targeted_process_setting.target,
+                        "settings"  => node_targeted_process_setting.settings
                       }
                     end
         node_new =  node_targeted_process_settings_new.map do |node_targeted_process_setting|
                       {
-                        'target'            => node_targeted_process_setting.target,
-                        "process_settings"  => node_targeted_process_setting.process_settings
+                        'target'    => node_targeted_process_setting.target,
+                        "settings"  => node_targeted_process_setting.settings
                       }
                     end
 

--- a/lib/process_settings/monitor.rb
+++ b/lib/process_settings/monitor.rb
@@ -81,7 +81,7 @@ module ProcessSettings
       result = statically_targeted_settings.reduce(:not_found) do |latest_result, target_and_settings|
         # find last value from matching targets
         if target_and_settings.target.target_key_matches?(full_context)
-          if (value = target_and_settings.process_settings.json_doc.mine(*path, not_found_value: :not_found)) != :not_found
+          if (value = target_and_settings.settings.json_doc.mine(*path, not_found_value: :not_found)) != :not_found
             latest_result = value
           end
         end

--- a/lib/process_settings/target_and_settings.rb
+++ b/lib/process_settings/target_and_settings.rb
@@ -6,7 +6,7 @@ require_relative 'settings'
 module ProcessSettings
   # This class encapsulates a single YAML file with target and process_settings.
   class TargetAndSettings
-    attr_reader :filename, :target, :process_settings
+    attr_reader :filename, :target, :settings
 
     def initialize(filename, target, settings)
       @filename = filename
@@ -15,7 +15,7 @@ module ProcessSettings
       @target = target
 
       settings.is_a?(Settings) or raise ArgumentError, "settings must be a ProcessSettings; got #{settings.inspect}"
-      @process_settings = settings
+      @settings = settings
     end
 
     def ==(rhs)
@@ -29,7 +29,7 @@ module ProcessSettings
     def to_json_doc
       {
         "target" => @target.json_doc,
-        "settings" => @process_settings.json_doc
+        "settings" => @settings.json_doc
       }
     end
 
@@ -37,9 +37,9 @@ module ProcessSettings
       def from_json_docs(filename, target_json_doc, settings_json_doc)
         target_json_doc = Target.new(target_json_doc)
 
-        process_settings = Settings.new(settings_json_doc)
+        settings = Settings.new(settings_json_doc)
 
-        new(filename, target_json_doc, process_settings)
+        new(filename, target_json_doc, settings)
       end
     end
 
@@ -49,7 +49,7 @@ module ProcessSettings
       if new_target == @target
         self
       else
-        self.class.new(@filename, new_target, @process_settings)
+        self.class.new(@filename, new_target, @settings)
       end
     end
   end

--- a/lib/process_settings/version.rb
+++ b/lib/process_settings/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ProcessSettings
-  VERSION = '0.4.2'
+  VERSION = '0.4.3'
 end

--- a/spec/lib/process_settings/monitor_spec.rb
+++ b/spec/lib/process_settings/monitor_spec.rb
@@ -108,7 +108,7 @@ describe ProcessSettings::Monitor do
       matching_settings = process_monitor.untargeted_settings.matching_settings({})
       expect(matching_settings.size).to eq(1)
       expect(matching_settings.first.target.json_doc).to eq(SAMPLE_SETTINGS.first['target'])
-      expect(matching_settings.first.process_settings.instance_variable_get(:@json_doc)).to eq(SAMPLE_SETTINGS.first['settings'])
+      expect(matching_settings.first.settings.instance_variable_get(:@json_doc)).to eq(SAMPLE_SETTINGS.first['settings'])
     end
 
     { modified: [File.expand_path(SETTINGS_PATH), [], []], added: [[], File.expand_path(SETTINGS_PATH), []] }.each do |type, args|
@@ -143,7 +143,7 @@ describe ProcessSettings::Monitor do
 
       matching_settings = process_monitor.untargeted_settings.matching_settings({})
       expect(matching_settings.size).to eq(1)
-      expect(matching_settings.first.process_settings.json_doc).to eq('sip' => { 'enabled' => true })
+      expect(matching_settings.first.settings.json_doc).to eq('sip' => { 'enabled' => true })
 
       sleep(0.15)
 
@@ -152,7 +152,7 @@ describe ProcessSettings::Monitor do
       sleep(0.3)  # allow enough time for the listen gem to notify us of the changed file
 
       matching_settings = process_monitor.untargeted_settings.matching_settings({})
-      expect(matching_settings.first.process_settings.json_doc).to eq({})
+      expect(matching_settings.first.settings.json_doc).to eq({})
     end
   end
 
@@ -268,7 +268,7 @@ describe ProcessSettings::Monitor do
       process_monitor.static_context = { 'region' => 'east' }
 
       result = process_monitor.statically_targeted_settings
-      settings = result.map { |s| s.process_settings.json_doc }
+      settings = result.map { |s| s.settings.json_doc }
 
       expect(settings).to eq([{ 'reject_call' => true }, { 'sip' => { 'enabled' => true } }, { 'reject_call' => false }, { 'collective' => true }])
     end
@@ -277,7 +277,7 @@ describe ProcessSettings::Monitor do
       process_monitor.static_context = { 'region' => 'west' }
 
       result = process_monitor.statically_targeted_settings
-      settings = result.map { |s| s.process_settings.json_doc }
+      settings = result.map { |s| s.settings.json_doc }
 
       expect(settings).to eq([{ 'sip' => { 'enabled' => true } }, {"reject_call" => false}])
     end
@@ -294,7 +294,7 @@ describe ProcessSettings::Monitor do
       result3 = process_monitor.statically_targeted_settings
       expect(result3.object_id).to_not eq(result.object_id)
 
-      settings = result3.map { |s| s.process_settings.json_doc }
+      settings = result3.map { |s| s.settings.json_doc }
       expect(settings).to eq([{ 'sip' => { 'enabled' => true } }, {"reject_call" => false}])
     end
   end

--- a/spec/lib/process_settings/target_and_settings_spec.rb
+++ b/spec/lib/process_settings/target_and_settings_spec.rb
@@ -9,13 +9,13 @@ describe ProcessSettings::TargetAndSettings do
       sample = sample_target_and_process_settings
       expect(sample.filename).to eq("settings.yml")
       expect(sample.target).to eq(sample_target)
-      expect(sample.process_settings).to eq(sample_process_settings)
+      expect(sample.settings).to eq(sample_process_settings)
     end
   end
 
-  describe "#process_settings" do
-    it "should return process_settings passed to #initialize" do
-      expect(sample_target_and_process_settings.process_settings).to eq(sample_process_settings)
+  describe "#settings" do
+    it "should return settings passed to #initialize" do
+      expect(sample_target_and_process_settings.settings).to eq(sample_process_settings)
     end
   end
 
@@ -26,7 +26,7 @@ describe ProcessSettings::TargetAndSettings do
       target_and_settings = described_class.from_json_docs("sip.yml", target_json_doc, target_settings_json_doc)
 
       expect(target_and_settings.target.json_doc).to eq(target_json_doc)
-      expect(target_and_settings.process_settings.json_doc).to eq(target_settings_json_doc)
+      expect(target_and_settings.settings.json_doc).to eq(target_settings_json_doc)
     end
   end
 
@@ -59,7 +59,7 @@ describe ProcessSettings::TargetAndSettings do
 
     it "is equal even if filename is different" do
       initial_value = sample_target_and_process_settings
-      dup_value = described_class.new("different_filename.yml", initial_value.target, initial_value.process_settings)
+      dup_value = described_class.new("different_filename.yml", initial_value.target, initial_value.settings)
 
       expect(initial_value).to eq(dup_value)
       expect(initial_value.eql?(dup_value)).to be_truthy
@@ -67,7 +67,7 @@ describe ProcessSettings::TargetAndSettings do
 
     it "is unequal if target is different" do
       initial_value = sample_target_and_process_settings
-      new_value = described_class.new(initial_value.filename, ProcessSettings::Target.new('region' => 'west'), initial_value.process_settings)
+      new_value = described_class.new(initial_value.filename, ProcessSettings::Target.new('region' => 'west'), initial_value.settings)
 
       expect(initial_value).to_not eq(new_value)
       expect(initial_value.eql?(new_value)).to be_falsey

--- a/spec/lib/process_settings/targeted_settings_spec.rb
+++ b/spec/lib/process_settings/targeted_settings_spec.rb
@@ -38,7 +38,7 @@ describe ProcessSettings::TargetedSettings do
     it "allows hash key access to settings" do
       target_and_settings = described_class.from_array(TARGETED_SETTINGS)
 
-      result = target_and_settings.targeted_settings_array.first.process_settings.json_doc.mine('honeypot', 'promo_number')
+      result = target_and_settings.targeted_settings_array.first.settings.json_doc.mine('honeypot', 'promo_number')
 
       expect(result).to eq('+18005554321')
     end
@@ -60,7 +60,7 @@ describe ProcessSettings::TargetedSettings do
         targeted_settings = described_class.from_file(TMP_FILE_PATH)
 
         expect(targeted_settings.targeted_settings_array.size).to eq(1)
-        expect(targeted_settings.targeted_settings_array.first.process_settings.json_doc.keys.first).to eq('honeypot')
+        expect(targeted_settings.targeted_settings_array.first.settings.json_doc.keys.first).to eq('honeypot')
         expect(targeted_settings.version).to eq(17)
       end
 
@@ -86,9 +86,9 @@ describe ProcessSettings::TargetedSettings do
       expect(target.json_doc).to eq(true)
       expect(target).to be_kind_of(ProcessSettings::Target)
 
-      process_settings = target_and_settings.targeted_settings_array.first.process_settings
-      expect(process_settings.json_doc).to eq('honeypot' => { 'promo_number' => '+18005554321' })
-      expect(process_settings).to be_kind_of(ProcessSettings::Settings)
+      settings = target_and_settings.targeted_settings_array.first.settings
+      expect(settings.json_doc).to eq('honeypot' => { 'promo_number' => '+18005554321' })
+      expect(settings).to be_kind_of(ProcessSettings::Settings)
     end
 
     it "confirms meta: is at end" do


### PR DESCRIPTION
- Fix process_settings_for_services to use `settings:` key instead of `process_settings:`.
- Change the internal method to match.
