### PR TITLE
don't check config if instance set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# CHANGELOG for `process_settings`
+
+Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.6.1] (Unreleased)
+
+### Added
+
+- Don't check for file_path or logger config if `instance =` has already been called;
+  it's not necessary.
+
+[0.6.1]: https://github.com/Invoca/process_settings/compare/v0.6.0...v0.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 
 ## [0.6.1] (Unreleased)
 
-### Added
+### Modified
 
 - Don't check for file_path or logger config if `instance =` has already been called;
   it's not necessary.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    process_settings (0.6.0)
+    process_settings (0.6.1)
       activesupport
       json
       listen (~> 3.0)
@@ -9,7 +9,7 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (6.0.2.1)
+    activesupport (6.0.2.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -109,4 +109,4 @@ DEPENDENCIES
   ruby-prof-flamegraph
 
 BUNDLED WITH
-   1.17.3
+   1.17.2

--- a/lib/process_settings/monitor.rb
+++ b/lib/process_settings/monitor.rb
@@ -151,9 +151,11 @@ module ProcessSettings
       end
 
       def instance
-        file_path or raise ArgumentError, "#{self}::file_path must be set before calling instance method"
-        logger or raise ArgumentError, "#{self}::logger must be set before calling instance method"
-        @instance ||= new(file_path, logger: logger)
+        @instance ||= begin
+                        file_path or raise ArgumentError, "#{self}::file_path must be set before calling instance method"
+                        logger or raise ArgumentError, "#{self}::logger must be set before calling instance method"
+                        new(file_path, logger: logger)
+                      end
       end
 
       def logger=(new_logger)

--- a/lib/process_settings/version.rb
+++ b/lib/process_settings/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ProcessSettings
-  VERSION = '0.6.0'
+  VERSION = '0.6.1'
 end

--- a/spec/lib/process_settings/monitor_spec.rb
+++ b/spec/lib/process_settings/monitor_spec.rb
@@ -63,6 +63,15 @@ describe ProcessSettings::Monitor do
         end.to raise_exception(ArgumentError, /::logger must be set before calling instance method/)
       end
 
+      it "should not raise an exception about file_path or logger if configured" do
+        described_class.file_path = nil
+        described_class.logger = nil
+        instance_stub = Object.new
+        described_class.instance = instance_stub
+
+        expect(described_class.instance).to eq(instance_stub)
+      end
+
       it "logger = should set the Listen logger" do
         Listen.logger = nil
         described_class.logger = logger


### PR DESCRIPTION
### Summary of Changes
- Don't check for file_path or logger config if `instance =` has already been called;
  it's not necessary.