### PR TITLE
No jira/revert ruby 2.6 syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,22 +4,23 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2020-03-31
+### Fixed
+- Reverted `rescue` syntax that required Ruby 2.6 since that broke some gems still on Ruby 2.4.
+
 ## [0.7.0] - 2020-03-31
-
 ### Added
-
 - `ProcessSettings::Monitor.when_updated` was added as a replacement to `ProcessSettings::Monitor.on_change`.  This allows the user
   to not only register a block to execute when a change is detected, but also allows the initial execution of the block during setup.
   This allows for cleaner, dryer code.
 
 ### Modified
-
 - Don't check for file_path or logger config if `instance =` has already been called;
   it's not necessary.
 
 ### Deprecated
-
 - `ProcessSettings::Monitor.on_change` has been deprecated. `ProcessSettings::Monitor.when_updated` should be used instead.
   This will be removed in version `1.0.0`
 
+[0.7.1]: https://github.com/Invoca/process_settings/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/Invoca/process_settings/compare/v0.6.0...v0.7.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    process_settings (0.7.0)
+    process_settings (0.7.1)
       activesupport
       json
       listen (~> 3.0)
@@ -9,12 +9,11 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (6.0.2.2)
+    activesupport (5.2.4.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-      zeitwerk (~> 2.2)
     ast (2.4.0)
     bump (0.6.1)
     coderay (1.1.2)
@@ -89,7 +88,6 @@ GEM
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     unicode-display_width (1.4.0)
-    zeitwerk (2.3.0)
 
 PLATFORMS
   ruby

--- a/lib/process_settings/monitor.rb
+++ b/lib/process_settings/monitor.rb
@@ -217,9 +217,11 @@ module ProcessSettings
 
     def call_when_updated_blocks
       @when_updated_blocks.each do |block|
-        block.call(self)
-      rescue => ex
-        logger.error("ProcessSettings::Monitor#call_when_updated_blocks rescued exception:\n#{ex.class}: #{ex.message}")
+        begin
+          block.call(self)
+        rescue => ex
+          logger.error("ProcessSettings::Monitor#call_when_updated_blocks rescued exception:\n#{ex.class}: #{ex.message}")
+        end
       end
     end
 

--- a/lib/process_settings/version.rb
+++ b/lib/process_settings/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ProcessSettings
-  VERSION = '0.7.0'
+  VERSION = '0.7.1'
 end


### PR DESCRIPTION
### Summary of Changes
- Reverted rescue syntax to use `begin`/`end` so it will still work with Ruby 2.4.

Note: I temporarily put the `.ruby-version` back to 2.4.2 and ran the tests to prove they pass there.