### PR TITLE
Tech 3417 unify statsd configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - Unreleased
+### Fixed
+- Fixed bug where `MonitorStub` was not responding to `#[]`
+
 ## [0.8.0] - 2020-04-07
 ### Added
 - `Monitor` instance now implements `#[]` and `ProcessSettings[]` delegates to it.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    process_settings (0.8.0)
+    process_settings (0.8.1.pre.1)
       activesupport
       json
       listen (~> 3.0)

--- a/lib/process_settings/testing/monitor_stub.rb
+++ b/lib/process_settings/testing/monitor_stub.rb
@@ -11,6 +11,10 @@ module ProcessSettings
         @settings_hash = HashWithHashPath[settings_hash]
       end
 
+      def [](*path, dynamic_context: {}, required: true)
+        targeted_value(*path, dynamic_context: dynamic_context, required: required)
+      end
+
       def targeted_value(*path, dynamic_context:, required: true)
         result = @settings_hash.mine(*path, not_found_value: :not_found)
 

--- a/lib/process_settings/version.rb
+++ b/lib/process_settings/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ProcessSettings
-  VERSION = '0.8.0'
+  VERSION = '0.8.1'
 end

--- a/lib/process_settings/version.rb
+++ b/lib/process_settings/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ProcessSettings
-  VERSION = '0.8.1'
+  VERSION = '0.8.1.pre.1'
 end

--- a/spec/lib/process_settings/testing/monitor_stub_spec.rb
+++ b/spec/lib/process_settings/testing/monitor_stub_spec.rb
@@ -34,4 +34,24 @@ describe ProcessSettings::Testing::MonitorStub do
       expect { subject.targeted_value('honeypot', 'unknown', dynamic_context: {}) }.to raise_exception(ProcessSettings::SettingsPathNotFound)
     end
   end
+
+  describe "#[]" do
+    it "returns values when found" do
+      result = subject['honeypot', 'answer_odds', dynamic_context: {}]
+      expect(result).to eq(100)
+    end
+
+    it "returns nil when not found and required: false" do
+      result = subject['honeypot', 'unknown', dynamic_context: {}, required: false]
+      expect(result).to eq(nil)
+    end
+
+    it "raises exception when not found and explicit required: true" do
+      expect { subject['honeypot', 'unknown', dynamic_context: {}, required: true] }.to raise_exception(ProcessSettings::SettingsPathNotFound)
+    end
+
+    it "raises exception when not found and default required: true" do
+      expect { subject['honeypot', 'unknown', dynamic_context: {}] }.to raise_exception(ProcessSettings::SettingsPathNotFound)
+    end
+  end
 end


### PR DESCRIPTION
### Summary of Changes
Adds the new `#[]` interface to the `MonitorStub` for testing
