### PR TITLE
Fix non existent nested targeting bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 
 ## [0.8.2] - 2020-04-22
 ### Fixed
-- Fixed bug where `Target` was raising an error when encountering a nested hash key that didn't exist in the static context
+- Fixed bug where an `ArgumentError` would raise out of `Target#with_static_context` when a target hash uses a nested key that doesn't exist in the static context
 
 ## [0.8.1] - 2020-04-21
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] - 2020-04-22
+### Fixed
+- Fixed bug where `Target` was raising an error when encountering a nested hash key that didn't exist in the static context
+
 ## [0.8.1] - 2020-04-21
 ### Fixed
 - Fixed bug where `MonitorStub` was not responding to `#[]`

--- a/lib/process_settings/monitor.rb
+++ b/lib/process_settings/monitor.rb
@@ -143,6 +143,7 @@ module ProcessSettings
       # this can be rather costly to do every time if the dynamic context is not changing
       # TODO: Warn in the case where dynamic context was attempting to change a static value
       # TODO: Cache the last used dynamic context as a potential optimization to avoid unnecessary deep merges
+      # TECH-4402 was created to address these todos
       full_context = dynamic_context.deep_merge(static_context)
       result = statically_targeted_settings.reduce(:not_found) do |latest_result, target_and_settings|
         # find last value from matching targets

--- a/lib/process_settings/target.rb
+++ b/lib/process_settings/target.rb
@@ -58,8 +58,8 @@ module ProcessSettings
             when true   # this hash entry is true, so omit it
             when false  # this hash entry is false, so hash is false
               return false
-            else
-              raise ArgumentError, "Got #{sub_value.inspect}???"
+            else        # sub-key does not exist, so hash is false
+              return false
             end
           else
             hash[key] = value

--- a/lib/process_settings/version.rb
+++ b/lib/process_settings/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ProcessSettings
-  VERSION = '0.8.1'
+  VERSION = '0.8.2'
 end

--- a/spec/lib/process_settings/target_spec.rb
+++ b/spec/lib/process_settings/target_spec.rb
@@ -310,7 +310,6 @@ describe ProcessSettings::Target do
           }
         end
 
-        # TODO: this is currently failing with a raised error "ArgumentError: Got {"something_else"=>"blue"}"
         it { should eq(false)}
       end
 

--- a/spec/lib/process_settings/target_spec.rb
+++ b/spec/lib/process_settings/target_spec.rb
@@ -313,7 +313,7 @@ describe ProcessSettings::Target do
         it { should eq(false)}
       end
 
-      describe "when the context contains non of the target hash" do
+      describe "when the context contains none of the target hash" do
         let(:target_hash) do
           {
             'something_else' => {

--- a/spec/lib/process_settings/target_spec.rb
+++ b/spec/lib/process_settings/target_spec.rb
@@ -255,5 +255,84 @@ describe ProcessSettings::Target do
 
       expect(result.json_doc).to eq(false)
     end
+
+    describe "when target hash has nested values" do
+      subject { described_class.new(target_hash).with_static_context(context_hash).json_doc }
+
+      describe "when the context contains the nested structure of the target hash" do
+        let(:target_hash) do
+          {
+            'services' => {
+              'region' => 'west'
+            }
+          }
+        end
+
+        describe "when the target matches the context" do
+          let(:context_hash) do
+            {
+              'services' => {
+                'region' => 'west'
+              }
+            }
+          end
+
+          it { should eq(true) }
+        end
+
+        describe "when the target does not match the context" do
+          let(:context_hash) {
+            {
+              'services' => {
+                'region' => 'east'
+              }
+            }
+          }
+
+          it { should eq(false)}
+        end
+      end
+
+      describe "when the context contains only the first level of the target hash" do
+        let(:target_hash) do
+          {
+            'services' => {
+              'something_else' => 'blue'
+            }
+          }
+        end
+
+        let(:context_hash) do
+          {
+            'services' => {
+              'region' => 'west'
+            }
+          }
+        end
+
+        # TODO: this is currently failing with a raised error "ArgumentError: Got {"something_else"=>"blue"}"
+        it { should eq(false)}
+      end
+
+      describe "when the context contains non of the target hash" do
+        let(:target_hash) do
+          {
+            'something_else' => {
+              'region' => 'west'
+            }
+          }
+        end
+
+        let(:context_hash) do
+          {
+            'services' => {
+              'region' => 'west'
+            }
+          }
+        end
+
+        it { should eq(target_hash) }
+      end
+    end
   end
 end


### PR DESCRIPTION
### Summary of Changes
When a nested target is provided, and a sub-hash key is missing from the static context, evaluate the targeting as false.