### PR TITLE
Tech 4370 update monitor stub to be smarter colin

### DIFF
--- a/lib/process_settings/abstract_monitor.rb
+++ b/lib/process_settings/abstract_monitor.rb
@@ -21,8 +21,6 @@ module ProcessSettings
       @static_context = {}
     end
 
-    # []
-    #
     # This is the main entry point for looking up settings on the Monitor instance.
     #
     # @example

--- a/lib/process_settings/abstract_monitor.rb
+++ b/lib/process_settings/abstract_monitor.rb
@@ -127,10 +127,15 @@ module ProcessSettings
 
       def clear_instance
         @instance = nil
+        @default_instance = nil
       end
 
       def instance
         @instance ||= default_instance
+      end
+
+      def default_instance
+        @default_instance ||= new_from_settings
       end
 
       def logger=(new_logger)

--- a/lib/process_settings/file_monitor.rb
+++ b/lib/process_settings/file_monitor.rb
@@ -11,9 +11,15 @@ require 'process_settings/hash_path'
 module ProcessSettings
   class FileMonitor < AbstractMonitor
     class << self
-      attr_accessor :file_path
+      attr_reader :file_path
 
-      def default_instance
+      def file_path=(new_file_path)
+        clear_instance
+
+        @file_path = new_file_path
+      end
+
+      def new_from_settings
         file_path or raise ArgumentError, "#{self}::file_path must be set before calling instance method"
         logger or raise ArgumentError, "#{self}::logger must be set before calling instance method"
         new(file_path, logger: logger)

--- a/lib/process_settings/settings.rb
+++ b/lib/process_settings/settings.rb
@@ -11,6 +11,8 @@ module ProcessSettings
     def initialize(json_doc)
       json_doc.is_a?(Hash) or raise ArgumentError, "ProcessSettings must be a Hash; got #{json_doc.inspect}"
 
+      AbstractMonitor.ensure_no_symbols(json_doc)
+
       @json_doc = HashWithHashPath[json_doc]
     end
 

--- a/lib/process_settings/target.rb
+++ b/lib/process_settings/target.rb
@@ -4,6 +4,8 @@ module ProcessSettings
   class Target
     include Comparable
 
+    TRUE_JSON_DOC = {}.freeze
+
     attr_reader :json_doc
 
     def initialize(json_doc)
@@ -11,7 +13,7 @@ module ProcessSettings
     end
 
     def target_key_matches?(context_hash)
-      @json_doc == {} || self.class.target_key_matches?(@json_doc, context_hash)
+      @json_doc == TRUE_JSON_DOC || self.class.target_key_matches?(@json_doc, context_hash)
     end
 
     def with_static_context(static_context_hash)
@@ -91,6 +93,12 @@ module ProcessSettings
         else
           target_value == context_hash
         end
+      end
+    end
+
+    class << self
+      def true_target
+        @true_target || new(TRUE_JSON_DOC)
       end
     end
   end

--- a/lib/process_settings/target_and_settings.rb
+++ b/lib/process_settings/target_and_settings.rb
@@ -11,10 +11,10 @@ module ProcessSettings
     def initialize(filename, target, settings)
       @filename = filename
 
-      target.is_a?(Target) or raise ArgumentError, "target must be a ProcessTarget; got #{target.inspect}"
+      target.is_a?(Target) or raise ArgumentError, "target must be a Target; got #{target.inspect}"
       @target = target
 
-      settings.is_a?(Settings) or raise ArgumentError, "settings must be a ProcessSettings; got #{settings.inspect}"
+      settings.is_a?(Settings) or raise ArgumentError, "settings must be a Settings; got #{settings.inspect}"
       @settings = settings
     end
 

--- a/lib/process_settings/testing/helpers.rb
+++ b/lib/process_settings/testing/helpers.rb
@@ -24,29 +24,14 @@ module ProcessSettings
         )
 
         new_process_settings = [
-          *default_process_settings.statically_targeted_settings,
+          *ProcessSettings::FileMonitor.default_instance.statically_targeted_settings,
           new_target_and_settings
         ]
 
         ProcessSettings::Monitor.instance = ProcessSettings::Testing::Monitor.new(
           new_process_settings,
-          logger: default_process_settings.logger
+          logger: ProcessSettings::FileMonitor.default_instance.logger
         )
-      end
-
-      # Returns the default process settings monitor instance that loads the combined_process_settings.yml
-      # file from disk
-      #
-      # @return ProcessSettings::Monitor default_process_settings
-      def default_process_settings
-        @default_process_settings ||= begin
-         ProcessSettings::Monitor.instance = nil
-         ProcessSettings::Monitor.instance
-        end
-      end
-
-      def reset_process_settings
-        ProcessSettings::Monitor.instance = default_process_settings
       end
     end
   end

--- a/lib/process_settings/testing/helpers.rb
+++ b/lib/process_settings/testing/helpers.rb
@@ -9,7 +9,6 @@ require 'process_settings/testing/monitor'
 module ProcessSettings
   module Testing
     module Helpers
-      extend self
 
       # Adds the given settings_hash as an override at the end of the process_settings array, with default targeting (true).
       # Therefore this will override these settings while leaving others alone.

--- a/lib/process_settings/testing/helpers.rb
+++ b/lib/process_settings/testing/helpers.rb
@@ -11,8 +11,6 @@ module ProcessSettings
     module Helpers
       extend self
 
-      TRUE_TARGET = ProcessSettings::Target.new({})
-
       # Adds the given settings_hash as an override at the end of the process_settings array, with default targeting (true).
       # Therefore this will override these settings while leaving others alone.
       #
@@ -22,7 +20,7 @@ module ProcessSettings
       def stub_process_settings(settings_hash)
         new_target_and_settings = ProcessSettings::TargetAndSettings.new(
           '<test_override>',
-          TRUE_TARGET,
+          Target::true_target,
           ProcessSettings::Settings.new(settings_hash.deep_stringify_keys)
         )
 

--- a/spec/lib/process_settings/settings_spec.rb
+++ b/spec/lib/process_settings/settings_spec.rb
@@ -25,7 +25,7 @@ describe ProcessSettings::Settings do
       end
     end
 
-    context "with a symbol key" do
+    context "with a symbol value" do
       let(:settings_json_doc) { { "log_level" => :debug } }
 
       it "raises" do

--- a/spec/lib/process_settings/settings_spec.rb
+++ b/spec/lib/process_settings/settings_spec.rb
@@ -5,37 +5,38 @@ require 'logger'
 require 'process_settings/settings'
 
 describe ProcessSettings::Settings do
-  describe "initialize" do
-    it "should take a json doc" do
-      process_settings = described_class.new("carrier" => "AT&T")
+  let(:settings_json_doc) { { "log_level" => "debug" } }
+  subject { described_class.new(settings_json_doc) }
 
-      expect(process_settings.json_doc.mine("carrier")).to eq("AT&T")
+  describe "#initialize" do
+    context "with a non-hash argument" do
+      let(:settings_json_doc) { "{}" }
+
+      it "raises" do
+        expect { subject }.to raise_exception(ArgumentError, /Settings must be a Hash/)
+      end
     end
 
-    it "should reject anything not a hash" do
-      expect do
-        described_class.new("{}")
-      end.to raise_exception(ArgumentError, /Settings must be a Hash/)
+    context "with a symbol key" do
+      let(:settings_json_doc) { { "gem" => { log_level: "debug" } } }
+
+      it "raises" do
+        expect { subject }.to raise_exception(ArgumentError, /symbol key :log_level found/)
+      end
     end
 
-    it "should reject symbol keys" do
-      expect do
-        described_class.new("gem" => { log_level: "debug" })
-      end.to raise_exception(ArgumentError, /symbol key :log_level found/)
-    end
+    context "with a symbol key" do
+      let(:settings_json_doc) { { "log_level" => :debug } }
 
-    it "should reject symbol values" do
-      expect do
-        described_class.new("gem" => { "log_level" => :debug })
-      end.to raise_exception(ArgumentError, /symbol value :debug found/)
+      it "raises" do
+        expect { subject }.to raise_exception(ArgumentError, /symbol value :debug found/)
+      end
     end
   end
 
   describe "#json_doc" do
-    it "should return what was stored" do
-      process_settings = described_class.new("carrier" => "AT&T")
-
-      expect(process_settings.json_doc).to eq("carrier" => "AT&T")
+    it "returns what was stored" do
+      expect(subject.json_doc).to eq(settings_json_doc)
     end
   end
 end

--- a/spec/lib/process_settings/settings_spec.rb
+++ b/spec/lib/process_settings/settings_spec.rb
@@ -17,6 +17,18 @@ describe ProcessSettings::Settings do
         described_class.new("{}")
       end.to raise_exception(ArgumentError, /Settings must be a Hash/)
     end
+
+    it "should reject symbol keys" do
+      expect do
+        described_class.new("gem" => { log_level: "debug" })
+      end.to raise_exception(ArgumentError, /symbol key :log_level found/)
+    end
+
+    it "should reject symbol values" do
+      expect do
+        described_class.new("gem" => { "log_level" => :debug })
+      end.to raise_exception(ArgumentError, /symbol value :debug found/)
+    end
   end
 
   describe "#json_doc" do

--- a/spec/lib/process_settings/target_spec.rb
+++ b/spec/lib/process_settings/target_spec.rb
@@ -337,9 +337,8 @@ describe ProcessSettings::Target do
 
   describe "class methods" do
     describe "true_target" do
-      it "uses the TRUE_JSON_DOC" do
-        expect(described_class.true_target.json_doc).to eq(described_class::TRUE_JSON_DOC)
-      end
+      subject { described_class.true_target.json_doc }
+      it { should eq({}) }
     end
   end
 end

--- a/spec/lib/process_settings/target_spec.rb
+++ b/spec/lib/process_settings/target_spec.rb
@@ -334,4 +334,12 @@ describe ProcessSettings::Target do
       end
     end
   end
+
+  describe "class methods" do
+    describe "true_target" do
+      it "uses the TRUE_JSON_DOC" do
+        expect(described_class.true_target.json_doc).to eq(described_class::TRUE_JSON_DOC)
+      end
+    end
+  end
 end

--- a/spec/lib/process_settings/testing/helpers_spec.rb
+++ b/spec/lib/process_settings/testing/helpers_spec.rb
@@ -24,8 +24,9 @@ describe ProcessSettings::Testing::Helpers do
     describe 'when a settings hash is provided' do
       let(:settings_hash) { { 'test' => { 'settings' => { 'id' => 12 } } } }
 
-      it 'is targetted first' do
-        expect(ProcessSettings['test', 'settings', 'id']).to eq(12)
+      describe 'when accessing an override'
+        subject { ProcessSettings['test', 'settings', 'id'] }
+        it { should eq(12) }
       end
 
       describe 'when accessing a default settings' do

--- a/spec/lib/process_settings/testing/helpers_spec.rb
+++ b/spec/lib/process_settings/testing/helpers_spec.rb
@@ -17,7 +17,7 @@ describe ProcessSettings::Testing::Helpers do
 
   describe '#stub_process_settings' do
     before do
-      expect(test_instance).to receive(:default_process_settings).and_return(default_process_settings).at_least(1).times
+      expect(ProcessSettings::FileMonitor).to receive(:default_instance).and_return(default_process_settings).at_least(1).times
       test_instance.stub_process_settings(settings_hash)
     end
 
@@ -31,26 +31,6 @@ describe ProcessSettings::Testing::Helpers do
       it 'falls back to defaults' do
         expect(ProcessSettings['honeypot', 'answer_odds']).to eq(100)
       end
-    end
-  end
-
-  describe '#default_process_settings' do
-    let(:default_instance) { double('default instance') }
-    subject { test_instance.default_process_settings }
-
-    before { allow(ProcessSettings::Monitor).to receive(:instance).and_return(default_instance) }
-
-    it { should be(default_instance) }
-  end
-
-  describe '#reset_process_settings' do
-    let(:default_process_settings) { double("default_process_settings") }
-
-    before { allow(test_instance).to receive(:default_process_settings).and_return(default_process_settings) }
-
-    it 'resets the ProcessSettings::Monitor instance back to the default' do
-      test_instance.reset_process_settings
-      expect(ProcessSettings::Monitor.instance).to be(default_process_settings)
     end
   end
 end

--- a/spec/lib/process_settings/testing/helpers_spec.rb
+++ b/spec/lib/process_settings/testing/helpers_spec.rb
@@ -28,8 +28,9 @@ describe ProcessSettings::Testing::Helpers do
         expect(ProcessSettings['test', 'settings', 'id']).to eq(12)
       end
 
-      it 'falls back to defaults' do
-        expect(ProcessSettings['honeypot', 'answer_odds']).to eq(100)
+      describe 'when accessing a default settings' do
+        subject { ProcessSettings['honeypot', 'answer_odds'] }
+        it { should eq(100) }
       end
     end
   end


### PR DESCRIPTION
- Moved default_instance into AbstractMonitor.
- Removed `extend self`.
- Added Target::TRUE_JSON_DOC and `Target.true_target` to extract commonality.
- Fixed a couple exceptions to refer to the now-correct class names.
- Enforce that symbols are not allowed as keys or as values.
