### PR TITLE
No jira make diff process settings process safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.10.0] - 2020-05-16
+## [0.10.2] - Unreleased
+### Fixed
+- Fixed bug where running `bin/diff_process_settings` multiple times would cause errors by
+switching the script to use `Tempdir` for generating temporary file name
+
+## [0.10.1] - 2020-05-16
 ### Fixed
 - Added missing `require_relative 'abstract_monitor'`.
 
@@ -67,6 +72,7 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 - `ProcessSettings::Monitor.on_change` has been deprecated; it will be removed in version `1.0.0`.
   `ProcessSettings::Monitor.when_updated` should be used instead.
 
+[0.10.2]: https://github.com/Invoca/process_settings/compare/v0.10.1...v0.10.2
 [0.10.1]: https://github.com/Invoca/process_settings/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/Invoca/process_settings/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/Invoca/process_settings/compare/v0.8.2...v0.9.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    process_settings (0.10.1)
+    process_settings (0.10.2)
       activesupport (>= 4.2, < 7)
       json
       listen (~> 3.0)

--- a/bin/diff_process_settings
+++ b/bin/diff_process_settings
@@ -7,6 +7,7 @@
 require 'fileutils'
 require 'optparse'
 require 'ostruct'
+require 'tempfile'
 
 PROGRAM_NAME = File.basename($PROGRAM_NAME)
 
@@ -41,19 +42,22 @@ input_files =
       end
     end
 
-system("rm -f tmp/combined_process_settings-A.yml tmp/combined_process_settings-B.yml")
+tempfile_a = Tempfile.new(['combined_process_settings', '.yml'], 'tmp').path
+tempfile_b = Tempfile.new(['combined_process_settings', '.yml'], 'tmp').path
+
+system("rm -f #{tempfile_a} #{tempfile_b}")
 
 # remove the meta-data from the end
-system("sed '/^- meta:$/,$d' #{input_files[0]} > tmp/combined_process_settings-A.yml")
-system("sed '/^- meta:$/,$d' #{input_files[1]} > tmp/combined_process_settings-B.yml")
+system("sed '/^- meta:$/,$d' #{input_files[0]} > #{tempfile_a}")
+system("sed '/^- meta:$/,$d' #{input_files[1]} > #{tempfile_b}")
 
 if options.silent
-  system("cmp --silent tmp/combined_process_settings-A.yml tmp/combined_process_settings-B.yml")
+  system("cmp --silent #{tempfile_a} #{tempfile_b}")
 else
-  system("diff -c tmp/combined_process_settings-A.yml tmp/combined_process_settings-B.yml | sed '1,3d'")
+  system("diff -c #{tempfile_a} #{tempfile_b} | sed '1,3d'")
 end
 exit_code = $?.exitstatus
 
-system("rm -f tmp/combined_process_settings-A.yml tmp/combined_process_settings-B.yml")
+system("rm -f #{tempfile_a} #{tempfile_b}")
 
 exit(exit_code)

--- a/lib/process_settings/version.rb
+++ b/lib/process_settings/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ProcessSettings
-  VERSION = '0.10.1'
+  VERSION = '0.10.2'
 end


### PR DESCRIPTION
## [0.10.2] - Unreleased
### Fixed
- Fixed bug where running `bin/diff_process_settings` multiple times would cause errors by
switching the script to use `Tempdir` for generating temporary file name