### PR TITLE
No jira fix bug in move to top level singleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.5] - Unreleased
+### Fixed
+- Fixed bug where setting a monitor instance at the `ProcessSettings` and the `ProcessSettings::Monitor`
+can cause unexpected errors due to two monitors being configured.
+
 ## [0.10.4] - 2020-05-21
 ### Fixed
 - Added missing `require 'active_support/deprecation'` in case caller hasn't done that.
@@ -80,6 +85,7 @@ switching the script to use `Tempdir` for generating temporary file name
 - `ProcessSettings::Monitor.on_change` has been deprecated; it will be removed in version `1.0.0`.
   `ProcessSettings::Monitor.when_updated` should be used instead.
 
+[0.10.5]: https://github.com/Invoca/process_settings/compare/v0.10.4...v0.10.5
 [0.10.4]: https://github.com/Invoca/process_settings/compare/v0.10.3...v0.10.4
 [0.10.3]: https://github.com/Invoca/process_settings/compare/v0.10.2...v0.10.3
 [0.10.2]: https://github.com/Invoca/process_settings/compare/v0.10.1...v0.10.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    process_settings (0.10.4)
+    process_settings (0.10.5)
       activesupport (>= 4.2, < 7)
       json
       listen (~> 3.0)

--- a/lib/process_settings.rb
+++ b/lib/process_settings.rb
@@ -22,14 +22,14 @@ module ProcessSettings
         raise ArgumentError, "Invalid monitor of type #{monitor.class.name} provided. Must be of type ProcessSettings::AbstractMonitor"
       end
 
-      @instance = monitor
+      Monitor.instance = monitor
     end
 
     # Getter method for retrieving the current monitor instance being used by ProcessSettings
     #
     # @return [ProcessSettings::AbstractMonitor]
     def instance
-      @instance ||= lazy_create_instance
+      Monitor.instance
     end
 
     # This is the main entry point for looking up settings in the process.
@@ -55,13 +55,6 @@ module ProcessSettings
     # @return setting value
     def [](*path, dynamic_context: {}, required: true)
       instance[*path, dynamic_context: dynamic_context, required: required]
-    end
-
-    private
-
-    def lazy_create_instance
-      ActiveSupport::Deprecation.warn("lazy creation of Monitor instance is deprecated and will be removed from ProcessSettings 1.0")
-      Monitor.instance
     end
   end
 end

--- a/lib/process_settings/monitor.rb
+++ b/lib/process_settings/monitor.rb
@@ -31,11 +31,11 @@ module ProcessSettings
       end
 
       def instance
-        ActiveSupport::Deprecation.warn("ProcessSettings::Monitor.instance is deprecated and will be removed in v1.0. Use ProcessSettings.instance instead.")
         @instance ||= default_instance
       end
 
       def default_instance
+        ActiveSupport::Deprecation.warn("ProcessSettings::Monitor.default_instance is deprecated and will be removed in v1.0. Use ProcessSettings.instance instead.")
         @default_instance ||= new_from_settings
       end
 

--- a/lib/process_settings/monitor.rb
+++ b/lib/process_settings/monitor.rb
@@ -35,7 +35,7 @@ module ProcessSettings
       end
 
       def default_instance
-        ActiveSupport::Deprecation.warn("ProcessSettings::Monitor.default_instance is deprecated and will be removed in v1.0. Use ProcessSettings.instance instead.")
+        ActiveSupport::Deprecation.warn("`ProcessSettings::Monitor.instance` is deprecated and will be removed in v1.0. Assign a `FileMonitor` object to `ProcessSettings.instance` instead.")
         @default_instance ||= new_from_settings
       end
 

--- a/lib/process_settings/version.rb
+++ b/lib/process_settings/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ProcessSettings
-  VERSION = '0.10.4'
+  VERSION = '0.10.5'
 end

--- a/spec/lib/process_settings_spec.rb
+++ b/spec/lib/process_settings_spec.rb
@@ -12,7 +12,7 @@ describe ProcessSettings do
 
     describe 'when lazy loading' do
       before do
-        expect(ActiveSupport::Deprecation).to receive(:warn).with("ProcessSettings::Monitor.default_instance is deprecated and will be removed in v1.0. Use ProcessSettings.instance instead.")
+        expect(ActiveSupport::Deprecation).to receive(:warn).with("`ProcessSettings::Monitor.instance` is deprecated and will be removed in v1.0. Assign a `FileMonitor` object to `ProcessSettings.instance` instead.")
         expect(ProcessSettings::Monitor).to receive(:new_from_settings).and_return(instance)
       end
 

--- a/spec/lib/process_settings_spec.rb
+++ b/spec/lib/process_settings_spec.rb
@@ -12,7 +12,6 @@ describe ProcessSettings do
 
     describe 'when lazy loading' do
       before do
-        expect(ActiveSupport::Deprecation).to receive(:warn).with("lazy creation of Monitor instance is deprecated and will be removed from ProcessSettings 1.0")
         expect(ProcessSettings::Monitor).to receive(:instance).and_return(instance)
       end
 
@@ -27,7 +26,7 @@ describe ProcessSettings do
   end
 
   describe '#instance=' do
-    subject { described_class.instance_variable_get(:@instance) }
+    subject { ProcessSettings::Monitor.instance_variable_get(:@instance) }
 
     describe 'when an AbstractMonitor object is provided' do
       let(:instance) { ProcessSettings::Testing::Monitor.new([], logger: Logger.new('/dev/null')) }

--- a/spec/lib/process_settings_spec.rb
+++ b/spec/lib/process_settings_spec.rb
@@ -12,7 +12,8 @@ describe ProcessSettings do
 
     describe 'when lazy loading' do
       before do
-        expect(ProcessSettings::Monitor).to receive(:instance).and_return(instance)
+        expect(ActiveSupport::Deprecation).to receive(:warn).with("ProcessSettings::Monitor.default_instance is deprecated and will be removed in v1.0. Use ProcessSettings.instance instead.")
+        expect(ProcessSettings::Monitor).to receive(:new_from_settings).and_return(instance)
       end
 
       it { should eq(instance) }


### PR DESCRIPTION
## [0.10.5] - Unreleased
### Fixed
- Fixed bug where setting a monitor instance at the `ProcessSettings` and the `ProcessSettings::Monitor`
can cause unexpected errors due to two monitors being configured.
