### PR TITLE
no-jira: deprecate new, fix memoize, and enforce logger contract

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,5 +1,2 @@
 --require spec_helper
 --color
---format RspecJunitFormatter
---out <%= ENV['JUNIT_OUTPUT'] || 'spec/reports/rspec.xml' %>
--fd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 - Deprecated lazy `instance` explicitly so that warning will point to caller.
 - Cleaned up noisy spec output including deprecation warnings.
 - Explicit contract enforcement: `raise ArgumentError` if logger: passed as `nil`.
+- Allow 'true' ('1') or 'false' ('0') values for `ENV['DISABLE_LISTEN_CHANGE_MONITORING']`;
+  default to 'false' when `Rails.env || ENV['SERVICE_ENV']) == 'test'`.
 
 ### Fixed
 - Fixed memoization of `Target.true_target`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
   1. `Rails.env` (if available)
   2. `ENV['RAILS_ENV']`
   3. `ENV['SERVICE_ENV']`
+- `ProcessSettings::FileMonitor#listen_thread_running?` indicates whether the listen thread
+  is running.
 
 ### Changed
 - Moved deprecation from `#initialize` up to `.new` so that warning will point to caller.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 
 ### Changed
 - Moved deprecation from `#initialize` up to `.new` so that warning will point to caller.
-- Deprecated lazy `instance` explicitly so that warning will point to caller.
+- Deprecated public `FileMonitor#start` method. This will become `private` in v1.0.
+- Deprecated lazy `ProcessSettings#instance` explicitly so that warning will point to caller.
 - Cleaned up noisy spec output including deprecation warnings.
 - Explicit contract enforcement: `raise ArgumentError` if logger: passed as `nil`.
 - Allow 'true' ('1') or 'false' ('0') values for `ENV['DISABLE_LISTEN_CHANGE_MONITORING']`;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.10.6] - Unreleased
+## [0.11.0] - Unreleased
+### Added
+- `ProcessSettings::Testing::Helpers` now automatically registers an `after`/`teardown` block to
+  set `ProcessSettings.instance` back to the default that was there before it was optionally
+  overridden by `stub_process_settings`.
+
 ### Changed
 - Moved deprecation from `#initialize` up to `.new` so that warning will point to caller.
 - Deprecated lazy `instance` explicitly so that warning will point to caller.
@@ -94,7 +99,7 @@ switching the script to use `Tempdir` for generating temporary file name
 - `ProcessSettings::Monitor.on_change` has been deprecated; it will be removed in version `1.0.0`.
   `ProcessSettings::Monitor.when_updated` should be used instead.
 
-[0.10.5]: https://github.com/Invoca/process_settings/compare/v0.10.4...v0.10.5
+[0.11.0]: https://github.com/Invoca/process_settings/compare/v0.10.4...v0.11.0
 [0.10.4]: https://github.com/Invoca/process_settings/compare/v0.10.3...v0.10.4
 [0.10.3]: https://github.com/Invoca/process_settings/compare/v0.10.2...v0.10.3
 [0.10.2]: https://github.com/Invoca/process_settings/compare/v0.10.1...v0.10.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,21 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.6] - Unreleased
+### Changed
+- Moved deprecation from `#initialize` up to `.new` so that warning will point to caller.
+- Deprecated lazy `instance` explicitly so that warning will point to caller.
+- Cleaned up noisy spec output including deprecation warnings.
+- Explicit contract enforcement: `raise ArgumentError` if logger: passed as `nil`.
+
+### Fixed
+- Fixed memoization of `Target.true_target`.
+
 ## [0.10.5] - 2020-05-27
 ### Fixed
 - Fixed bug where setting a monitor instance at the `ProcessSettings` and the `ProcessSettings::Monitor`
 can cause unexpected errors due to two monitors being configured.
 
-## [0.10.4] - 2020-05-21
 ### Fixed
 - Added missing `require 'active_support/deprecation'` in case caller hasn't done that.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 - Fixed bug where setting a monitor instance at the `ProcessSettings` and the `ProcessSettings::Monitor`
 can cause unexpected errors due to two monitors being configured.
 
+## [0.10.4] - 2020-05-21
 ### Fixed
 - Added missing `require 'active_support/deprecation'` in case caller hasn't done that.
 
@@ -111,7 +112,8 @@ switching the script to use `Tempdir` for generating temporary file name
 - `ProcessSettings::Monitor.on_change` has been deprecated; it will be removed in version `1.0.0`.
   `ProcessSettings::Monitor.when_updated` should be used instead.
 
-[0.11.0]: https://github.com/Invoca/process_settings/compare/v0.10.4...v0.11.0
+[0.11.0]: https://github.com/Invoca/process_settings/compare/v0.10.5...v0.11.0
+[0.10.5]: https://github.com/Invoca/process_settings/compare/v0.10.4...v0.10.5
 [0.10.4]: https://github.com/Invoca/process_settings/compare/v0.10.3...v0.10.4
 [0.10.3]: https://github.com/Invoca/process_settings/compare/v0.10.2...v0.10.3
 [0.10.2]: https://github.com/Invoca/process_settings/compare/v0.10.1...v0.10.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 - `ProcessSettings::Testing::Helpers` now automatically registers an `after`/`teardown` block to
   set `ProcessSettings.instance` back to the default that was there before it was optionally
   overridden by `stub_process_settings`.
+- `ProcessSettings::FileMonitor.initialize` now accepts an optional keyword argument `environment:`.
+  This is an environment string like can be found in `Rails.env` for Rails applications.
+  It is used to infer to disable the listen thread in the 'test' environment.
+  If left to its default of `nil`, the environment is inferred by the first of these values that is present:
+  1. `Rails.env` (if available)
+  2. `ENV['RAILS_ENV']`
+  3. `ENV['SERVICE_ENV']`
 
 ### Changed
 - Moved deprecation from `#initialize` up to `.new` so that warning will point to caller.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    process_settings (0.11.0.pre.1)
+    process_settings (0.11.0.pre.2)
       activesupport (>= 4.2, < 7)
       json
       listen (~> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    process_settings (0.10.5)
+    process_settings (0.10.6)
       activesupport (>= 4.2, < 7)
       json
       listen (~> 3.0)
@@ -31,8 +31,8 @@ GEM
       tins (~> 1.6)
     diff-lcs (1.3)
     docile (1.3.1)
-    ffi (1.12.2)
-    i18n (1.8.2)
+    ffi (1.13.1)
+    i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
     listen (3.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    process_settings (0.10.6.pre.1)
+    process_settings (0.11.0.pre.1)
       activesupport (>= 4.2, < 7)
       json
       listen (~> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    process_settings (0.10.6)
+    process_settings (0.10.6.pre.1)
       activesupport (>= 4.2, < 7)
       json
       listen (~> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    process_settings (0.11.0.pre.2)
+    process_settings (0.11.0.pre.4)
       activesupport (>= 4.2, < 7)
       json
       listen (~> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    process_settings (0.11.0.pre.6)
+    process_settings (0.11.0.pre.7)
       activesupport (>= 4.2, < 7)
       json
       listen (~> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    process_settings (0.11.0.pre.4)
+    process_settings (0.11.0.pre.6)
       activesupport (>= 4.2, < 7)
       json
       listen (~> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    process_settings (0.11.0.pre.7)
+    process_settings (0.11.0.pre.8)
       activesupport (>= 4.2, < 7)
       json
       listen (~> 3.0)

--- a/lib/process_settings/abstract_monitor.rb
+++ b/lib/process_settings/abstract_monitor.rb
@@ -15,7 +15,7 @@ module ProcessSettings
     attr_reader :static_context, :statically_targeted_settings
 
     def initialize(logger:)
-      @logger = logger
+      @logger = logger or raise ArgumentError, "logger must be not be nil"
       @on_change_callbacks = []
       @when_updated_blocks = Set.new
       @static_context = {}

--- a/lib/process_settings/file_monitor.rb
+++ b/lib/process_settings/file_monitor.rb
@@ -29,8 +29,12 @@ module ProcessSettings
     end
     deprecate :start, deprecator: ActiveSupport::Deprecation.new('1.0', 'ProcessSettings') # will become private
 
-    def enable_listen_thread?(environment)
-      !disable_listen_thread?
+    def listen_thread_running?
+      !@listener.nil?
+    end
+
+    def enable_listen_thread?(environment = nil)
+      !disable_listen_thread?(environment)
     end
 
     def disable_listen_thread?(environment = nil)
@@ -82,6 +86,7 @@ module ProcessSettings
     # stops listening for changes
     def stop
       @listener&.stop
+      @listener = nil
     end
 
     def service_env

--- a/lib/process_settings/file_monitor.rb
+++ b/lib/process_settings/file_monitor.rb
@@ -33,6 +33,8 @@ module ProcessSettings
       !@listener.nil?
     end
 
+    private
+
     def enable_listen_thread?(environment = nil)
       !disable_listen_thread?(environment)
     end
@@ -44,13 +46,11 @@ module ProcessSettings
       when 'false', '0'
         false
       when nil
-        environment || service_env == 'test'
+        (environment || service_env) == 'test'
       else
         raise ArgumentError, "DISABLE_LISTEN_CHANGE_MONITORING has unknown value #{ENV['DISABLE_LISTEN_CHANGE_MONITORING'].inspect}"
       end
     end
-
-    private
 
     # optionally starts listening for changes, then loads current settings
     # Note: If with_listen_thread is truthy, this method creates a new thread that will be

--- a/lib/process_settings/file_monitor.rb
+++ b/lib/process_settings/file_monitor.rb
@@ -45,7 +45,7 @@ module ProcessSettings
         end
       end
 
-      unless ENV['DISABLE_LISTEN_CHANGE_MONITORING']
+      if enable_listen_thread?
         @listener.start
       end
 
@@ -58,7 +58,28 @@ module ProcessSettings
       @listener&.stop
     end
 
+    def enable_listen_thread?
+      !disable_listen_thread?
+    end
+
+    def disable_listen_thread?
+      case ENV['DISABLE_LISTEN_CHANGE_MONITORING']
+      when 'true', '1'
+        true
+      when 'false', '0'
+        false
+      when nil
+        service_env == 'test'
+      else
+        raise ArgumentError, "DISABLE_LISTEN_CHANGE_MONITORING has unknown value #{ENV['DISABLE_LISTEN_CHANGE_MONITORING'].inspect}"
+      end
+    end
+
     private
+
+    def service_env
+      (defined?(Rails) && Rails.environmnent) || ENV['SERVICE_ENV']
+    end
 
     # Loads the most recent settings from disk
     def load_untargeted_settings

--- a/lib/process_settings/file_monitor.rb
+++ b/lib/process_settings/file_monitor.rb
@@ -78,7 +78,7 @@ module ProcessSettings
     private
 
     def service_env
-      (defined?(Rails) && Rails.environmnent) || ENV['SERVICE_ENV']
+      (defined?(Rails) && Rails.env) || ENV['SERVICE_ENV']
     end
 
     # Loads the most recent settings from disk

--- a/lib/process_settings/monitor.rb
+++ b/lib/process_settings/monitor.rb
@@ -30,11 +30,16 @@ module ProcessSettings
       end
 
       def instance
-        @instance ||= default_instance
+        if @instance
+          @instance
+        else
+          ActiveSupport::Deprecation.warn("`ProcessSettings::Monitor.instance` lazy create is deprecated and will be removed in v1.0. Assign a `FileMonitor` object to `ProcessSettings.instance =` instead.")
+          @instance = default_instance
+        end
       end
 
       def default_instance
-        ActiveSupport::Deprecation.warn("`ProcessSettings::Monitor.instance` is deprecated and will be removed in v1.0. Assign a `FileMonitor` object to `ProcessSettings.instance` instead.")
+        ActiveSupport::Deprecation.warn("`ProcessSettings::Monitor.instance` is deprecated and will be removed in v1.0. Assign a `FileMonitor` object to `ProcessSettings.instance =` instead.")
         @default_instance ||= new_from_settings
       end
 

--- a/lib/process_settings/monitor.rb
+++ b/lib/process_settings/monitor.rb
@@ -13,7 +13,6 @@ module ProcessSettings
       attr_writer :instance
 
       def file_path=(new_file_path)
-        ActiveSupport::Deprecation.warn("ProcessSettings::Monitor.file_path= is deprecated and will be removed in v1.0.")
         clear_instance
 
         @file_path = new_file_path

--- a/lib/process_settings/target.rb
+++ b/lib/process_settings/target.rb
@@ -98,7 +98,7 @@ module ProcessSettings
 
     class << self
       def true_target
-        @true_target || new(TRUE_JSON_DOC)
+        @true_target ||= new(TRUE_JSON_DOC)
       end
     end
   end

--- a/lib/process_settings/testing/helpers.rb
+++ b/lib/process_settings/testing/helpers.rb
@@ -9,7 +9,20 @@ require 'process_settings/testing/monitor'
 module ProcessSettings
   module Testing
     module Helpers
+      class << self
+        def included(including_klass)
+          after_method =
+            if including_klass.respond_to?(:teardown)
+              :teardown
+            else
+              :after
+            end
 
+          including_klass.send(after_method) do
+            ProcessSettings.instance = initial_instance
+          end
+        end
+      end
       # Adds the given settings_hash as an override at the end of the process_settings array, with default targeting (true).
       # Therefore this will override these settings while leaving others alone.
       #
@@ -33,8 +46,6 @@ module ProcessSettings
           logger: initial_instance.logger
         )
       end
-
-      private
 
       def initial_instance
         @initial_instance ||= ProcessSettings.instance

--- a/lib/process_settings/testing/monitor_stub.rb
+++ b/lib/process_settings/testing/monitor_stub.rb
@@ -11,8 +11,14 @@ module ProcessSettings
   module Testing
     # This class implements the Monitor#targeted_value interface but is stubbed to use a simple hash in tests
     class MonitorStub
+      class << self
+        def new(*_args)
+          ActiveSupport::Deprecation.warn("ProcessSettings::Testing::MonitorStub is deprecated and will be removed in future versions. Use ProcessSettings::Testing::Monitor instead.", caller)
+          super
+        end
+      end
+
       def initialize(settings_hash)
-        ActiveSupport::Deprecation.warn("ProcessSettings::Testing::MonitorStub is deprecated and will be removed in future versions. Use ProcessSettings::Testing::Monitor instead.", caller)
         @settings_hash = HashWithHashPath[settings_hash]
       end
 

--- a/lib/process_settings/version.rb
+++ b/lib/process_settings/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ProcessSettings
-  VERSION = '0.11.0.pre.4'
+  VERSION = '0.11.0.pre.6'
 end

--- a/lib/process_settings/version.rb
+++ b/lib/process_settings/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ProcessSettings
-  VERSION = '0.11.0.pre.1'
+  VERSION = '0.11.0.pre.2'
 end

--- a/lib/process_settings/version.rb
+++ b/lib/process_settings/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ProcessSettings
-  VERSION = '0.10.6.pre.1'
+  VERSION = '0.11.0.pre.1'
 end

--- a/lib/process_settings/version.rb
+++ b/lib/process_settings/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ProcessSettings
-  VERSION = '0.11.0.pre.7'
+  VERSION = '0.11.0.pre.8'
 end

--- a/lib/process_settings/version.rb
+++ b/lib/process_settings/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ProcessSettings
-  VERSION = '0.10.5'
+  VERSION = '0.10.6'
 end

--- a/lib/process_settings/version.rb
+++ b/lib/process_settings/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ProcessSettings
-  VERSION = '0.10.6'
+  VERSION = '0.10.6.pre.1'
 end

--- a/lib/process_settings/version.rb
+++ b/lib/process_settings/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ProcessSettings
-  VERSION = '0.11.0.pre.6'
+  VERSION = '0.11.0.pre.7'
 end

--- a/lib/process_settings/version.rb
+++ b/lib/process_settings/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ProcessSettings
-  VERSION = '0.11.0.pre.2'
+  VERSION = '0.11.0.pre.4'
 end

--- a/spec/lib/process_settings/file_monitor_spec.rb
+++ b/spec/lib/process_settings/file_monitor_spec.rb
@@ -98,6 +98,8 @@ describe ProcessSettings::FileMonitor do
       expect(matching_settings.size).to eq(1)
       expect(matching_settings.first.settings.json_doc).to eq('sip' => { 'enabled' => true })
 
+      callback = "callback not called"
+      process_monitor.when_updated(initial_update: false) { callback = "callback called" }
       sleep(0.15)
 
       File.write(SETTINGS_PATH, EMPTY_SAMPLE_SETTINGS_YAML)
@@ -105,7 +107,7 @@ describe ProcessSettings::FileMonitor do
       sleep(0.5)  # allow enough time for the listen gem to notify us of the changed file
 
       matching_settings = process_monitor.untargeted_settings.matching_settings({})
-      expect(matching_settings.first.settings.json_doc).to eq({})
+      expect(matching_settings.first.settings.json_doc).to eq({}), callback
     end
   end
 

--- a/spec/lib/process_settings/file_monitor_spec.rb
+++ b/spec/lib/process_settings/file_monitor_spec.rb
@@ -37,7 +37,7 @@ describe ProcessSettings::FileMonitor do
     it_should_behave_like(
       "AbstractMonitor",
       File.expand_path(SETTINGS_PATH, __dir__),
-      Logger.new(STDERR).tap { |logger| logger.level = ::Logger::ERROR },
+      Logger.new('/dev/null').tap { |logger| logger.level = ::Logger::ERROR },
       ['sip', 'enabled']
     )
 

--- a/spec/lib/process_settings/file_monitor_spec.rb
+++ b/spec/lib/process_settings/file_monitor_spec.rb
@@ -17,7 +17,7 @@ describe ProcessSettings::FileMonitor do
   EAST_SETTINGS_YAML = EAST_SETTINGS.to_yaml
   EMPTY_SAMPLE_SETTINGS_YAML = EMPTY_SAMPLE_SETTINGS.to_yaml
 
-  let(:logger) { Logger.new(STDERR).tap { |logger| logger.level = ::Logger::ERROR } }
+  let(:logger) { Logger.new('/dev/null').tap { |logger| logger.level = ::Logger::ERROR } }
 
   RSpec.configuration.before(:each) do
     Listen.stop
@@ -144,8 +144,8 @@ describe ProcessSettings::FileMonitor do
 
     describe "#when_updated" do
       it 'calls back to block once when registered (by default)' do
-        when_updated_proc_1 = Proc.new { true }
-        when_updated_proc_2 = Proc.new { true }
+        when_updated_proc_1 = -> { true }
+        when_updated_proc_2 = -> { true }
 
         expect(when_updated_proc_1).to receive(:call).with(process_monitor)
         expect(when_updated_proc_2).to receive(:call).with(process_monitor)
@@ -155,8 +155,8 @@ describe ProcessSettings::FileMonitor do
       end
 
       it 'calls back to block once when registered (initial_update: true)' do
-        when_updated_proc_1 = Proc.new { true }
-        when_updated_proc_2 = Proc.new { true }
+        when_updated_proc_1 = -> { true }
+        when_updated_proc_2 = -> { true }
 
         expect(when_updated_proc_1).to receive(:call).with(process_monitor)
         expect(when_updated_proc_2).to receive(:call).with(process_monitor)
@@ -166,8 +166,8 @@ describe ProcessSettings::FileMonitor do
       end
 
       it 'does not call back to block when registered (initial_update: false)' do
-        when_updated_proc_1 = Proc.new { true }
-        when_updated_proc_2 = Proc.new { true }
+        when_updated_proc_1 = -> { true }
+        when_updated_proc_2 = -> { true }
 
         expect(when_updated_proc_1).to_not receive(:call).with(process_monitor)
         expect(when_updated_proc_2).to_not receive(:call).with(process_monitor)
@@ -183,7 +183,7 @@ describe ProcessSettings::FileMonitor do
       end
 
       it 'is idempotent' do
-        when_updated_proc = Proc.new { true }
+        when_updated_proc = -> { true }
         expect(when_updated_proc).to receive(:call).with(process_monitor)
 
         process_monitor.when_updated(&when_updated_proc)
@@ -191,8 +191,8 @@ describe ProcessSettings::FileMonitor do
       end
 
       it 'calls back to each block when static_context changes' do
-        when_updated_proc_1 = Proc.new { true }
-        when_updated_proc_2 = Proc.new { true }
+        when_updated_proc_1 = -> { true }
+        when_updated_proc_2 = -> { true }
 
         expect(when_updated_proc_1).to receive(:call).with(process_monitor).exactly(2)
         expect(when_updated_proc_2).to receive(:call).with(process_monitor).exactly(2)
@@ -203,8 +203,8 @@ describe ProcessSettings::FileMonitor do
       end
 
       it 'calls back to each block when the file changes' do
-        when_updated_proc_1 = Proc.new { true }
-        when_updated_proc_2 = Proc.new { true }
+        when_updated_proc_1 = -> { true }
+        when_updated_proc_2 = -> { true }
 
         expect(when_updated_proc_1).to receive(:call).with(process_monitor).exactly(2)
         expect(when_updated_proc_2).to receive(:call).with(process_monitor).exactly(2)
@@ -218,8 +218,8 @@ describe ProcessSettings::FileMonitor do
       end
 
       it 'does not call back to the blocks on a noop change' do
-        when_updated_proc_1 = Proc.new { true }
-        when_updated_proc_2 = Proc.new { true }
+        when_updated_proc_1 = -> { true }
+        when_updated_proc_2 = -> { true }
 
         expect(when_updated_proc_1).to receive(:call).with(process_monitor)
         expect(when_updated_proc_2).to receive(:call).with(process_monitor)
@@ -233,8 +233,8 @@ describe ProcessSettings::FileMonitor do
       end
 
       it "keeps going even if exceptions raised" do
-        when_updated_proc_1 = Proc.new { true }
-        when_updated_proc_2 = Proc.new { true }
+        when_updated_proc_1 = -> { true }
+        when_updated_proc_2 = -> { true }
 
         expect(when_updated_proc_1).to receive(:call).with(process_monitor).and_raise(StandardError, 'oops 1').exactly(2)
         expect(when_updated_proc_2).to receive(:call).with(process_monitor).and_raise(StandardError, 'oops 2').exactly(2)

--- a/spec/lib/process_settings/file_monitor_spec.rb
+++ b/spec/lib/process_settings/file_monitor_spec.rb
@@ -102,7 +102,7 @@ describe ProcessSettings::FileMonitor do
 
       File.write(SETTINGS_PATH, EMPTY_SAMPLE_SETTINGS_YAML)
 
-      sleep(0.3)  # allow enough time for the listen gem to notify us of the changed file
+      sleep(0.5)  # allow enough time for the listen gem to notify us of the changed file
 
       matching_settings = process_monitor.untargeted_settings.matching_settings({})
       expect(matching_settings.first.settings.json_doc).to eq({})
@@ -214,7 +214,7 @@ describe ProcessSettings::FileMonitor do
 
         sleep(0.15)
         File.write(SETTINGS_PATH, EMPTY_SAMPLE_SETTINGS_YAML)
-        sleep(0.3)  # allow enough time for the listen gem to notify us of the changed file
+        sleep(0.5)  # allow enough time for the listen gem to notify us of the changed file
       end
 
       it 'does not call back to the blocks on a noop change' do
@@ -229,7 +229,7 @@ describe ProcessSettings::FileMonitor do
 
         sleep(0.15)
         File.write(SETTINGS_PATH, EAST_SETTINGS_YAML)
-        sleep(0.3)  # allow enough time for the listen gem to notify us of the changed file
+        sleep(0.5)  # allow enough time for the listen gem to notify us of the changed file
       end
 
       it "keeps going even if exceptions raised" do
@@ -247,7 +247,7 @@ describe ProcessSettings::FileMonitor do
 
         sleep(0.15)
         File.write(SETTINGS_PATH, EMPTY_SAMPLE_SETTINGS_YAML)
-        sleep(0.3)  # allow enough time for the listen gem to notify us of the changed file
+        sleep(0.5)  # allow enough time for the listen gem to notify us of the changed file
       end
     end
 
@@ -283,7 +283,7 @@ describe ProcessSettings::FileMonitor do
 
         File.write(SETTINGS_PATH, EMPTY_SAMPLE_SETTINGS_YAML)
 
-        sleep(0.3)  # allow enough time for the listen gem to notify us of the changed file
+        sleep(0.5)  # allow enough time for the listen gem to notify us of the changed file
 
         expect(callbacks).to eq([1, 2])
       end
@@ -314,7 +314,7 @@ describe ProcessSettings::FileMonitor do
 
         expect(callbacks).to eq([])
 
-        sleep(0.3)  # allow enough time for the listen gem to notify us of the changed file
+        sleep(0.5)  # allow enough time for the listen gem to notify us of the changed file
       end
     end
   end

--- a/spec/lib/process_settings/monitor_spec.rb
+++ b/spec/lib/process_settings/monitor_spec.rb
@@ -150,15 +150,15 @@ describe ProcessSettings::Monitor do
 
       it "should start listener depending on DISABLE_LISTEN_CHANGE_MONITORING variable" do
         allow_any_instance_of(ActiveSupport::Deprecation).to receive(:warn).with(any_args)
-        described_class.file_path = "./spec/fixtures/production/combined_process_settings.yml"
-        described_class.logger = logger
+        file_path = "./spec/fixtures/production/combined_process_settings.yml"
 
+        allow(ENV).to receive(:[]).with("SERVICE_ENV").and_return("test")
         allow(ENV).to receive(:[]).with("DISABLE_LISTEN_CHANGE_MONITORING").and_return("1")
-        instance = described_class.instance
+        instance = ProcessSettings::FileMonitor.new(file_path, logger: logger)
         expect(instance.instance_variable_get(:@listener).state).to eq(:initializing)
-        described_class.clear_instance
-        allow(ENV).to receive(:[]).with("DISABLE_LISTEN_CHANGE_MONITORING").and_return(nil)
-        instance = described_class.instance
+        allow(ENV).to receive(:[]).with("SERVICE_ENV").and_return(nil)
+        allow(ENV).to receive(:[]).with("DISABLE_LISTEN_CHANGE_MONITORING").and_return("0")
+        instance = ProcessSettings::FileMonitor.new(file_path, logger: logger)
         expect(instance.instance_variable_get(:@listener).state).to eq(:processing_events)
       end
     end

--- a/spec/lib/process_settings/monitor_spec.rb
+++ b/spec/lib/process_settings/monitor_spec.rb
@@ -17,7 +17,7 @@ describe ProcessSettings::Monitor do
   MONITOR_EAST_SETTINGS_YAML = MONITOR_EAST_SETTINGS.to_yaml
   MONITOR_EMPTY_MONITOR_SAMPLE_SETTINGS_YAML = MONITOR_EMPTY_MONITOR_SAMPLE_SETTINGS.to_yaml
 
-  let(:logger) { Logger.new(STDERR).tap { |logger| logger.level = ::Logger::ERROR } }
+  let(:logger) { Logger.new('/dev/null').tap { |logger| logger.level = ::Logger::ERROR } }
 
   RSpec.configuration.before(:each) do
     Listen.stop
@@ -31,8 +31,15 @@ describe ProcessSettings::Monitor do
     before { File.write(settings_file, MONITOR_EAST_SETTINGS_YAML) }
     after  { FileUtils.rm_f(settings_file) }
 
+    before do
+      allow(ActiveSupport::Deprecation).to receive(:warn).with(anything, :initialize)
+      allow_any_instance_of(ActiveSupport::Deprecation).to receive(:warn).with("initialize is deprecated and will be removed from ProcessSettings 1.0", anything)
+    end
+
     let(:settings_file) { File.expand_path(MONITOR_SETTINGS_PATH, __dir__) }
-    let(:monitor) { described_class.new(settings_file, logger: logger) }
+    let(:monitor) do
+      described_class.new(settings_file, logger: logger)
+    end
 
     it_should_behave_like(
       "AbstractMonitor",
@@ -50,7 +57,11 @@ describe ProcessSettings::Monitor do
 
   describe "class methods" do
     describe '[] operator' do
-      subject(:process_monitor) { described_class.new(MONITOR_SETTINGS_PATH, logger: logger) }
+      subject(:process_monitor) do
+        allow(ActiveSupport::Deprecation).to receive(:warn).with(anything, :initialize)
+        allow_any_instance_of(ActiveSupport::Deprecation).to receive(:warn).with("initialize is deprecated and will be removed from ProcessSettings 1.0", anything)
+        described_class.new(MONITOR_SETTINGS_PATH, logger: logger)
+      end
 
       before do
         File.write(MONITOR_SETTINGS_PATH, MONITOR_EAST_SETTINGS_YAML)
@@ -82,6 +93,7 @@ describe ProcessSettings::Monitor do
       end
 
       it "should raise an exception if not configured" do
+        allow_any_instance_of(ActiveSupport::Deprecation).to receive(:warn).with(any_args)
         described_class.file_path = nil
 
         expect do
@@ -90,6 +102,7 @@ describe ProcessSettings::Monitor do
       end
 
       it "should raise an exception if logger not set" do
+        allow_any_instance_of(ActiveSupport::Deprecation).to receive(:warn).with(any_args)
         described_class.file_path = "./spec/fixtures/production/combined_process_settings.yml"
 
         expect do
@@ -98,6 +111,7 @@ describe ProcessSettings::Monitor do
       end
 
       it "should not raise an exception about file_path or logger if configured" do
+        allow_any_instance_of(ActiveSupport::Deprecation).to receive(:warn).with(any_args)
         described_class.file_path = nil
         described_class.logger = nil
         instance_stub = Object.new
@@ -107,12 +121,14 @@ describe ProcessSettings::Monitor do
       end
 
       it "logger = should set the Listen logger" do
+        allow_any_instance_of(ActiveSupport::Deprecation).to receive(:warn).with(any_args)
         Listen.logger = nil
         described_class.logger = logger
         expect(Listen.logger).to be(logger)
       end
 
       it "logger = should leave the Listen logger alone if already set" do
+        allow_any_instance_of(ActiveSupport::Deprecation).to receive(:warn).with(any_args)
         existing_logger = Logger.new(STDOUT)
         Listen.logger = existing_logger
         described_class.logger = logger
@@ -121,6 +137,7 @@ describe ProcessSettings::Monitor do
       end
 
       it "should return a global instance" do
+        allow_any_instance_of(ActiveSupport::Deprecation).to receive(:warn).with(any_args)
         described_class.file_path = "./spec/fixtures/production/combined_process_settings.yml"
         described_class.logger = logger
 
@@ -132,6 +149,7 @@ describe ProcessSettings::Monitor do
       end
 
       it "should start listener depending on DISABLE_LISTEN_CHANGE_MONITORING variable" do
+        allow_any_instance_of(ActiveSupport::Deprecation).to receive(:warn).with(any_args)
         described_class.file_path = "./spec/fixtures/production/combined_process_settings.yml"
         described_class.logger = logger
 
@@ -151,6 +169,7 @@ describe ProcessSettings::Monitor do
       end
 
       it "stores nil into instance" do
+        allow_any_instance_of(ActiveSupport::Deprecation).to receive(:warn).with(any_args)
         described_class.instance
         expect(described_class.instance_variable_get(:@instance)).to be
         described_class.instance = nil
@@ -164,6 +183,7 @@ describe ProcessSettings::Monitor do
       end
 
       it "stores value into instance" do
+        allow_any_instance_of(ActiveSupport::Deprecation).to receive(:warn).with(any_args)
         new_instance = Object.new
         described_class.instance = new_instance
         expect(described_class.instance).to be(new_instance)
@@ -181,6 +201,7 @@ describe ProcessSettings::Monitor do
     end
 
     it "should read from disk the first time" do
+      allow_any_instance_of(ActiveSupport::Deprecation).to receive(:warn).with(any_args)
       process_monitor = described_class.new(MONITOR_SETTINGS_PATH, logger: logger)
       matching_settings = process_monitor.untargeted_settings.matching_settings({})
       expect(matching_settings.size).to eq(1)
@@ -190,6 +211,7 @@ describe ProcessSettings::Monitor do
 
     { modified: [File.expand_path(MONITOR_SETTINGS_PATH), [], []], added: [[], File.expand_path(MONITOR_SETTINGS_PATH), []] }.each do |type, args|
       it "should re-read from disk when callback triggered with #{type}" do
+        allow_any_instance_of(ActiveSupport::Deprecation).to receive(:warn).with(any_args)
         file_change_notifier_stub = Object.new
         class << file_change_notifier_stub
           def to(path)
@@ -215,6 +237,7 @@ describe ProcessSettings::Monitor do
     end
 
     it "should re-read from disk when watcher triggered" do
+      allow_any_instance_of(ActiveSupport::Deprecation).to receive(:warn).with(any_args)
       process_monitor = described_class.new(MONITOR_SETTINGS_PATH, logger: logger)
 
       matching_settings = process_monitor.untargeted_settings.matching_settings({})
@@ -233,7 +256,11 @@ describe ProcessSettings::Monitor do
   end
 
   context "with process_settings" do
-    subject(:process_monitor) { described_class.new(MONITOR_SETTINGS_PATH, logger: logger) }
+    subject(:process_monitor) do
+      allow(ActiveSupport::Deprecation).to receive(:warn).with(anything, :initialize)
+      allow_any_instance_of(ActiveSupport::Deprecation).to receive(:warn).with(any_args)
+      described_class.new(MONITOR_SETTINGS_PATH, logger: logger)
+    end
 
     before do
       File.write(MONITOR_SETTINGS_PATH, MONITOR_EAST_SETTINGS_YAML)
@@ -443,7 +470,11 @@ describe ProcessSettings::Monitor do
   end
 
   describe "#statically_targeted_settings" do
-    let(:process_monitor) { described_class.new(MONITOR_SETTINGS_PATH, logger: logger) }
+    let(:process_monitor) do
+      allow(ActiveSupport::Deprecation).to receive(:warn).with(any_args)
+      allow_any_instance_of(ActiveSupport::Deprecation).to receive(:warn).with(any_args)
+      described_class.new(MONITOR_SETTINGS_PATH, logger: logger)
+    end
 
     before do
       File.write(MONITOR_SETTINGS_PATH, MONITOR_EAST_SETTINGS_YAML)
@@ -489,7 +520,11 @@ describe ProcessSettings::Monitor do
   end
 
   describe "#targeted_value" do
-    let(:process_monitor) { described_class.new(MONITOR_SETTINGS_PATH, logger: logger) }
+    let(:process_monitor) do
+      allow(ActiveSupport::Deprecation).to receive(:warn).with(anything, :initialize)
+      allow_any_instance_of(ActiveSupport::Deprecation).to receive(:warn).with("initialize is deprecated and will be removed from ProcessSettings 1.0", anything)
+      described_class.new(MONITOR_SETTINGS_PATH, logger: logger)
+    end
 
     before do
       File.write(MONITOR_SETTINGS_PATH, MONITOR_EAST_SETTINGS_YAML)

--- a/spec/lib/process_settings/monitor_spec.rb
+++ b/spec/lib/process_settings/monitor_spec.rb
@@ -248,7 +248,7 @@ describe ProcessSettings::Monitor do
 
       File.write(MONITOR_SETTINGS_PATH, MONITOR_EMPTY_MONITOR_SAMPLE_SETTINGS_YAML)
 
-      sleep(0.3)  # allow enough time for the listen gem to notify us of the changed file
+      sleep(0.5)  # allow enough time for the listen gem to notify us of the changed file
 
       matching_settings = process_monitor.untargeted_settings.matching_settings({})
       expect(matching_settings.first.settings.json_doc).to eq({})
@@ -364,7 +364,7 @@ describe ProcessSettings::Monitor do
 
         sleep(0.15)
         File.write(MONITOR_SETTINGS_PATH, MONITOR_EMPTY_MONITOR_SAMPLE_SETTINGS_YAML)
-        sleep(0.3)  # allow enough time for the listen gem to notify us of the changed file
+        sleep(0.5)  # allow enough time for the listen gem to notify us of the changed file
       end
 
       it 'does not call back to the blocks on a noop change' do
@@ -379,7 +379,7 @@ describe ProcessSettings::Monitor do
 
         sleep(0.15)
         File.write(MONITOR_SETTINGS_PATH, MONITOR_EAST_SETTINGS_YAML)
-        sleep(0.3)  # allow enough time for the listen gem to notify us of the changed file
+        sleep(0.5)  # allow enough time for the listen gem to notify us of the changed file
       end
 
       it "keeps going even if exceptions raised" do
@@ -397,7 +397,7 @@ describe ProcessSettings::Monitor do
 
         sleep(0.15)
         File.write(MONITOR_SETTINGS_PATH, MONITOR_EMPTY_MONITOR_SAMPLE_SETTINGS_YAML)
-        sleep(0.3)  # allow enough time for the listen gem to notify us of the changed file
+        sleep(0.5)  # allow enough time for the listen gem to notify us of the changed file
       end
     end
 
@@ -433,7 +433,7 @@ describe ProcessSettings::Monitor do
 
         File.write(MONITOR_SETTINGS_PATH, MONITOR_EMPTY_MONITOR_SAMPLE_SETTINGS_YAML)
 
-        sleep(0.3)  # allow enough time for the listen gem to notify us of the changed file
+        sleep(0.5)  # allow enough time for the listen gem to notify us of the changed file
 
         expect(callbacks).to eq([1, 2])
       end
@@ -464,7 +464,7 @@ describe ProcessSettings::Monitor do
 
         expect(callbacks).to eq([])
 
-        sleep(0.3)  # allow enough time for the listen gem to notify us of the changed file
+        sleep(0.5)  # allow enough time for the listen gem to notify us of the changed file
       end
     end
   end

--- a/spec/lib/process_settings/monitor_spec.rb
+++ b/spec/lib/process_settings/monitor_spec.rb
@@ -155,7 +155,7 @@ describe ProcessSettings::Monitor do
         allow(ENV).to receive(:[]).with("SERVICE_ENV").and_return("test")
         allow(ENV).to receive(:[]).with("DISABLE_LISTEN_CHANGE_MONITORING").and_return("1")
         instance = ProcessSettings::FileMonitor.new(file_path, logger: logger)
-        expect(instance.instance_variable_get(:@listener).state).to eq(:initializing)
+        expect(instance.instance_variable_get(:@listener)).to be_nil
         allow(ENV).to receive(:[]).with("SERVICE_ENV").and_return(nil)
         allow(ENV).to receive(:[]).with("DISABLE_LISTEN_CHANGE_MONITORING").and_return("0")
         instance = ProcessSettings::FileMonitor.new(file_path, logger: logger)

--- a/spec/lib/process_settings/target_spec.rb
+++ b/spec/lib/process_settings/target_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 require 'logger'
-require 'process_settings/target'
+require_relative '../../../lib/process_settings/target'
 
 describe ProcessSettings::Target do
   describe "#process_target" do

--- a/spec/lib/process_settings/testing/helpers_spec.rb
+++ b/spec/lib/process_settings/testing/helpers_spec.rb
@@ -8,7 +8,7 @@ describe ProcessSettings::Testing::Helpers do
     include ProcessSettings::Testing::Helpers
   end
 
-  let(:logger) { Logger.new(STDERR) }
+  let(:logger) { Logger.new('/dev/null') }
   let(:test_instance) { TestClass.new }
   let(:combined_process_settings_fixture_path) { File.expand_path("../../../fixtures/production/combined_process_settings.yml", __dir__) }
   let(:initial_process_settings) do

--- a/spec/lib/process_settings/testing/monitor_stub_spec.rb
+++ b/spec/lib/process_settings/testing/monitor_stub_spec.rb
@@ -13,7 +13,10 @@ describe ProcessSettings::Testing::MonitorStub do
                       status_change_min_days: 10
                   EOS
 
-  subject { ProcessSettings::Testing::MonitorStub.new(SETTINGS_HASH) }
+  subject do
+    allow(ActiveSupport::Deprecation).to receive(:warn).with("ProcessSettings::Testing::MonitorStub is deprecated and will be removed in future versions. Use ProcessSettings::Testing::Monitor instead.", anything)
+    ProcessSettings::Testing::MonitorStub.new(SETTINGS_HASH)
+  end
 
   describe "#targeted_value" do
     it "returns values when found" do

--- a/spec/lib/process_settings_spec.rb
+++ b/spec/lib/process_settings_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require_relative '../../lib/process_settings/testing/monitor'
 
 describe ProcessSettings do
   before { described_class.instance = nil }
@@ -12,7 +13,8 @@ describe ProcessSettings do
 
     describe 'when lazy loading' do
       before do
-        expect(ActiveSupport::Deprecation).to receive(:warn).with("`ProcessSettings::Monitor.instance` is deprecated and will be removed in v1.0. Assign a `FileMonitor` object to `ProcessSettings.instance` instead.")
+        expect(ActiveSupport::Deprecation).to receive(:warn).with("`ProcessSettings::Monitor.instance` lazy create is deprecated and will be removed in v1.0. Assign a `FileMonitor` object to `ProcessSettings.instance =` instead.")
+        expect(ActiveSupport::Deprecation).to receive(:warn).with("`ProcessSettings::Monitor.instance` is deprecated and will be removed in v1.0. Assign a `FileMonitor` object to `ProcessSettings.instance =` instead.")
         expect(ProcessSettings::Monitor).to receive(:new_from_settings).and_return(instance)
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'rspec_junit_formatter'
 require 'process_settings'
 
 require 'pry'
@@ -7,6 +8,9 @@ require 'coveralls'
 Coveralls.wear!
 
 RSpec.configure do |config|
+  config.add_formatter  :progress
+  config.add_formatter  RspecJunitFormatter, ENV['JUNIT_OUTPUT'] || 'spec/reports/rspec.xml'
+
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end

--- a/spec/support/shared_examples_for_monitors.rb
+++ b/spec/support/shared_examples_for_monitors.rb
@@ -2,7 +2,11 @@
 
 # RSpec shared examples for ProcessSettings::Monitor
 RSpec.shared_examples "AbstractMonitor" do |settings, logger, scoped_setting|
-  let(:monitor) { described_class.new(settings, logger: logger) }
+  let(:monitor) do
+    allow(ActiveSupport::Deprecation).to receive(:warn).with(anything, :initialize)
+    allow_any_instance_of(ActiveSupport::Deprecation).to receive(:deprecation_warning).with(any_args)
+    described_class.new(settings, logger: logger)
+  end
 
   describe "#initialize" do
     subject { monitor }
@@ -11,6 +15,11 @@ RSpec.shared_examples "AbstractMonitor" do |settings, logger, scoped_setting|
 
     it "defaults to empty static context" do
       expect(monitor.static_context).to eq({})
+    end
+
+    it "raises ArgumentError if logger: nil" do
+      allow_any_instance_of(ActiveSupport::Deprecation).to receive(:deprecation_warning).with(any_args)
+      expect { described_class.new([], logger: nil) }.to raise_exception(ArgumentError, /logger must be not be nil/)
     end
   end
 


### PR DESCRIPTION
## [0.11.0] - Unreleased
### Added
- `ProcessSettings::Testing::Helpers` now automatically registers an `after`/`teardown` block to
  set `ProcessSettings.instance` back to the default that was there before it was optionally
  overridden by `stub_process_settings`.

### Changed
- Moved deprecation from `#initialize` up to `.new` so that warning will point to caller.
- Deprecated lazy `instance` explicitly so that warning will point to caller.
- Cleaned up noisy spec output including deprecation warnings.
- Explicit contract enforcement: `raise ArgumentError` if logger: passed as `nil`.
- Allow 'true' ('1') or 'false' ('0') values for `ENV['DISABLE_LISTEN_CHANGE_MONITORING']`;
  default to 'false' when `Rails.env || ENV['SERVICE_ENV']) == 'test'`.

### Fixed
- Fixed memoization of `Target.true_target`.