### PR TITLE
no-jira: explicit null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2020-08-06
+### Changed
+- `bin/combine_process_settings` now uses an explicit `: null` value for null (nil in Ruby) values, vs.
+the former implicit `: ` at end of line. This is important because the trailing space was sometimes deleted
+when committed and pushed, depending on editor settings and git(hub) hook configuration. 
+
 ## [0.11.0] - 2020-06-16
 ### Added
 - `ProcessSettings::Testing::Helpers` now automatically registers an `after`/`teardown` block to
@@ -112,6 +118,7 @@ switching the script to use `Tempdir` for generating temporary file name
 - `ProcessSettings::Monitor.on_change` has been deprecated; it will be removed in version `1.0.0`.
   `ProcessSettings::Monitor.when_updated` should be used instead.
 
+[0.11.0]: https://github.com/Invoca/process_settings/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/Invoca/process_settings/compare/v0.10.5...v0.11.0
 [0.10.5]: https://github.com/Invoca/process_settings/compare/v0.10.4...v0.10.5
 [0.10.4]: https://github.com/Invoca/process_settings/compare/v0.10.3...v0.10.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    process_settings (0.11.0)
+    process_settings (0.12.0)
       activesupport (>= 4.2, < 7)
       json
       listen (~> 3.0)
@@ -9,7 +9,7 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (6.0.3.1)
+    activesupport (6.0.3.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -32,7 +32,7 @@ GEM
     diff-lcs (1.3)
     docile (1.3.1)
     ffi (1.13.1)
-    i18n (1.8.3)
+    i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
     listen (3.2.1)
@@ -93,7 +93,7 @@ GEM
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.4.0)
-    zeitwerk (2.3.0)
+    zeitwerk (2.4.0)
 
 PLATFORMS
   ruby

--- a/bin/combine_process_settings
+++ b/bin/combine_process_settings
@@ -86,7 +86,7 @@ combined_settings = read_and_combine_settings(Pathname.new(options.root_folder) 
 version_number = options.version || default_version_number(options.initial_filename)
 combined_settings << end_marker(version_number)
 
-yaml = combined_settings.to_yaml
+yaml = combined_settings.to_yaml.gsub(/: $/, ": null") # implicit null caused problems because of trailing whitespace
 yaml_with_warning_comment = add_warning_comment(yaml, options.root_folder, PROGRAM_NAME, SETTINGS_FOLDER)
 
 output_filename     = options.output_filename

--- a/lib/process_settings/version.rb
+++ b/lib/process_settings/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ProcessSettings
-  VERSION = '0.11.0'
+  VERSION = '0.12.0'
 end

--- a/spec/bin/combine_process_settings_spec.rb
+++ b/spec/bin/combine_process_settings_spec.rb
@@ -61,7 +61,7 @@ describe 'combine_process_settings' do
           honeypot:
             max_recording_seconds: 600
             answer_odds: 100
-            status_change_min_days: 10
+            status_change_min_days: null
       - filename: stop_incoming_requests.yml
         target:
           region: east

--- a/spec/bin/diff_process_settings_spec.rb
+++ b/spec/bin/diff_process_settings_spec.rb
@@ -12,7 +12,7 @@ describe 'diff_process_settings' do
       honeypot:
 !       max_recording_seconds: 300
         answer_odds: 100
-        status_change_min_days: 10
+        status_change_min_days: null
   - filename: telecom/log_level.yml
 --- 5,11 ----
   - filename: honeypot.yml
@@ -20,7 +20,7 @@ describe 'diff_process_settings' do
       honeypot:
 !       max_recording_seconds: 600
         answer_odds: 100
-        status_change_min_days: 10
+        status_change_min_days: null
   - filename: telecom/log_level.yml
     EOS
   end
@@ -44,7 +44,7 @@ describe 'diff_process_settings' do
             honeypot:
       !       max_recording_seconds: 300
               answer_odds: 100
-              status_change_min_days: 10
+              status_change_min_days: null
         - filename: telecom/log_level.yml
       --- 5,11 ----
         - filename: honeypot.yml
@@ -52,7 +52,7 @@ describe 'diff_process_settings' do
             honeypot:
       !       max_recording_seconds: 600
               answer_odds: 100
-              status_change_min_days: 10
+              status_change_min_days: null
         - filename: telecom/log_level.yml
     EOS
   end

--- a/spec/fixtures/production/combined_process_settings-16-0.yml
+++ b/spec/fixtures/production/combined_process_settings-16-0.yml
@@ -7,7 +7,7 @@
     honeypot:
       max_recording_seconds: 300
       answer_odds: 100
-      status_change_min_days: 10
+      status_change_min_days: null
 - filename: telecom/log_level.yml
   target:
     app: telecom

--- a/spec/fixtures/production/combined_process_settings-16-50.yml
+++ b/spec/fixtures/production/combined_process_settings-16-50.yml
@@ -7,7 +7,7 @@
     honeypot:
       max_recording_seconds: 300
       answer_odds: 100
-      status_change_min_days: 10
+      status_change_min_days: null
 - filename: telecom/log_level.yml
   target:
     app: telecom

--- a/spec/fixtures/production/combined_process_settings-16.yml
+++ b/spec/fixtures/production/combined_process_settings-16.yml
@@ -7,7 +7,7 @@
     honeypot:
       max_recording_seconds: 300
       answer_odds: 100
-      status_change_min_days: 10
+      status_change_min_days: null
 - filename: telecom/log_level.yml
   target:
     app: telecom

--- a/spec/fixtures/production/combined_process_settings-18-1.yml
+++ b/spec/fixtures/production/combined_process_settings-18-1.yml
@@ -7,7 +7,7 @@
     honeypot:
       max_recording_seconds: 600
       answer_odds: 100
-      status_change_min_days: 10
+      status_change_min_days: null
 - filename: telecom/log_level.yml
   target:
     app: telecom

--- a/spec/fixtures/production/combined_process_settings-18.yml
+++ b/spec/fixtures/production/combined_process_settings-18.yml
@@ -7,7 +7,7 @@
     honeypot:
       max_recording_seconds: 600
       answer_odds: 100
-      status_change_min_days: 10
+      status_change_min_days: null
 - filename: telecom/log_level.yml
   target:
     app: telecom

--- a/spec/fixtures/production/combined_process_settings-18b.yml
+++ b/spec/fixtures/production/combined_process_settings-18b.yml
@@ -7,7 +7,7 @@
     honeypot:
       max_recording_seconds: 600
       answer_odds: 200
-      status_change_min_days: 10
+      status_change_min_days: null
 - filename: telecom/log_level.yml
   target:
     app: telecom

--- a/spec/fixtures/production/combined_process_settings-19.yml
+++ b/spec/fixtures/production/combined_process_settings-19.yml
@@ -7,7 +7,7 @@
     honeypot:
       max_recording_seconds: 600
       answer_odds: 100
-      status_change_min_days: 10
+      status_change_min_days: null
 - filename: telecom/log_level.yml
   target:
     app: telecom

--- a/spec/fixtures/production/combined_process_settings.yml
+++ b/spec/fixtures/production/combined_process_settings.yml
@@ -7,7 +7,7 @@
     honeypot:
       max_recording_seconds: 600
       answer_odds: 100
-      status_change_min_days: 10
+      status_change_min_days: null
 - filename: telecom/log_level.yml
   target:
     app: telecom

--- a/spec/fixtures/production/settings/honeypot.yml
+++ b/spec/fixtures/production/settings/honeypot.yml
@@ -3,4 +3,4 @@ settings:
   honeypot:
     max_recording_seconds: 600
     answer_odds: 100
-    status_change_min_days: 10
+    status_change_min_days: null

--- a/spec/lib/process_settings/testing/monitor_stub_spec.rb
+++ b/spec/lib/process_settings/testing/monitor_stub_spec.rb
@@ -10,7 +10,7 @@ describe ProcessSettings::Testing::MonitorStub do
                     honeypot:
                       max_recording_seconds: 300
                       answer_odds: 100
-                      status_change_min_days: 10
+                      status_change_min_days: null
                   EOS
 
   subject do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,4 +18,6 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
   config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  RSpec::Support::ObjectFormatter.default_instance.max_formatted_output_length = 2_000
 end


### PR DESCRIPTION
## [0.12.0] - 2020-08-06
### Changed
- `bin/combine_process_settings` now uses an explicit `: null` value for null (nil in Ruby) values, vs.
the former implicit `: ` at end of line. This is important because the trailing space was sometimes deleted
when committed and pushed, depending on editor settings and git(hub) hook configuration. 