### PR TITLE
no-jira/libyaml 0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2020-08-06
+### Changed
+- Removed explicit `: null` because `libyaml` 0.2.5 doesn't write the trailing space to key off.
+Instead, explicitly depend on the `psych` gem and check that libyaml is at least 0.2.5.
+
 ## [0.12.0] - 2020-08-06
 ### Changed
 - `bin/combine_process_settings` now uses an explicit `: null` value for null (nil in Ruby) values, vs.
@@ -118,7 +123,8 @@ switching the script to use `Tempdir` for generating temporary file name
 - `ProcessSettings::Monitor.on_change` has been deprecated; it will be removed in version `1.0.0`.
   `ProcessSettings::Monitor.when_updated` should be used instead.
 
-[0.11.0]: https://github.com/Invoca/process_settings/compare/v0.11.0...v0.12.0
+[0.13.0]: https://github.com/Invoca/process_settings/compare/v0.12.0...v0.13.0
+[0.12.0]: https://github.com/Invoca/process_settings/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/Invoca/process_settings/compare/v0.10.5...v0.11.0
 [0.10.5]: https://github.com/Invoca/process_settings/compare/v0.10.4...v0.10.5
 [0.10.4]: https://github.com/Invoca/process_settings/compare/v0.10.3...v0.10.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.13.0] - 2020-08-06
+## [0.13.1] - 2020-08-06
 ### Changed
 - Removed explicit `: null` because `libyaml` 0.2.5 doesn't write the trailing space to key off.
 Instead, explicitly depend on the `psych` gem and check that libyaml is at least 0.2.5.
+
+##  0.13.0 - 2020-08-06
+### Not Used
 
 ## [0.12.0] - 2020-08-06
 ### Changed
@@ -123,7 +126,7 @@ switching the script to use `Tempdir` for generating temporary file name
 - `ProcessSettings::Monitor.on_change` has been deprecated; it will be removed in version `1.0.0`.
   `ProcessSettings::Monitor.when_updated` should be used instead.
 
-[0.13.0]: https://github.com/Invoca/process_settings/compare/v0.12.0...v0.13.0
+[0.13.1]: https://github.com/Invoca/process_settings/compare/v0.12.0...v0.13.1
 [0.12.0]: https://github.com/Invoca/process_settings/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/Invoca/process_settings/compare/v0.10.5...v0.11.0
 [0.10.5]: https://github.com/Invoca/process_settings/compare/v0.10.4...v0.10.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    process_settings (0.13.0)
+    process_settings (0.13.1)
       activesupport (>= 4.2, < 7)
       json
       listen (~> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    process_settings (0.12.0)
+    process_settings (0.13.0)
       activesupport (>= 4.2, < 7)
       json
       listen (~> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       activesupport (>= 4.2, < 7)
       json
       listen (~> 3.0)
+      psych (~> 3.2)
 
 GEM
   remote: http://rubygems.org/
@@ -47,6 +48,7 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    psych (3.2.0)
     rainbow (3.0.0)
     rake (12.3.3)
     rb-fsevent (0.10.4)

--- a/bin/combine_process_settings
+++ b/bin/combine_process_settings
@@ -75,11 +75,33 @@ def add_warning_comment(yaml, root_folder, program_name, settings_folder)
   yaml.sub("\n", "\n" + warning_comment)
 end
 
+MINIMUM_LIBYAML_VERSION = '0.2.5' # So that null (nil) values don't have trailing spaces.
+
+def check_libyaml_version
+  if Gem::Version.new(Psych::LIBYAML_VERSION) < Gem::Version.new(MINIMUM_LIBYAML_VERSION)
+    warn <<~EOS
+
+      #{PROGRAM_NAME} error: libyaml version #{Psych::LIBYAML_VERSION} must be at least #{MINIMUM_LIBYAML_VERSION}. Try:
+
+          brew update && upgrade libyaml
+
+      You may also need:
+
+          gem install psych -- --enable-bundled-libyaml
+    EOS
+
+    exit(1)
+  end
+end
+
+
 #
 # main
 #
 
 options = parse_options(ARGV.dup)
+
+check_libyaml_version
 
 combined_settings = read_and_combine_settings(Pathname.new(options.root_folder) + SETTINGS_FOLDER)
 

--- a/bin/combine_process_settings
+++ b/bin/combine_process_settings
@@ -86,7 +86,7 @@ combined_settings = read_and_combine_settings(Pathname.new(options.root_folder) 
 version_number = options.version || default_version_number(options.initial_filename)
 combined_settings << end_marker(version_number)
 
-yaml = combined_settings.to_yaml.gsub(/: $/, ": null") # implicit null caused problems because of trailing whitespace
+yaml = combined_settings.to_yaml
 yaml_with_warning_comment = add_warning_comment(yaml, options.root_folder, PROGRAM_NAME, SETTINGS_FOLDER)
 
 output_filename     = options.output_filename

--- a/bin/combine_process_settings
+++ b/bin/combine_process_settings
@@ -83,7 +83,7 @@ def check_libyaml_version
 
       #{PROGRAM_NAME} error: libyaml version #{Psych::LIBYAML_VERSION} must be at least #{MINIMUM_LIBYAML_VERSION}. Try:
 
-          brew update && upgrade libyaml
+          brew update && brew upgrade libyaml
 
       You may also need:
 

--- a/lib/process_settings/version.rb
+++ b/lib/process_settings/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ProcessSettings
-  VERSION = '0.13.0'
+  VERSION = '0.13.1'
 end

--- a/lib/process_settings/version.rb
+++ b/lib/process_settings/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ProcessSettings
-  VERSION = '0.12.0'
+  VERSION = '0.13.0'
 end

--- a/process_settings.gemspec
+++ b/process_settings.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'activesupport', '>= 4.2', '< 7'
   spec.add_runtime_dependency 'json'
   spec.add_runtime_dependency 'listen', '~> 3.0'
+  spec.add_runtime_dependency 'psych', '~> 3.2' # so latest libyaml will be pulled in
 end

--- a/spec/bin/combine_process_settings_spec.rb
+++ b/spec/bin/combine_process_settings_spec.rb
@@ -61,7 +61,7 @@ describe 'combine_process_settings' do
           honeypot:
             max_recording_seconds: 600
             answer_odds: 100
-            status_change_min_days: null
+            status_change_min_days: 10
       - filename: stop_incoming_requests.yml
         target:
           region: east

--- a/spec/bin/combine_process_settings_spec.rb
+++ b/spec/bin/combine_process_settings_spec.rb
@@ -61,7 +61,7 @@ describe 'combine_process_settings' do
           honeypot:
             max_recording_seconds: 600
             answer_odds: 100
-            status_change_min_days: 10
+            status_change_min_days:
       - filename: stop_incoming_requests.yml
         target:
           region: east

--- a/spec/bin/diff_process_settings_spec.rb
+++ b/spec/bin/diff_process_settings_spec.rb
@@ -12,7 +12,7 @@ describe 'diff_process_settings' do
       honeypot:
 !       max_recording_seconds: 300
         answer_odds: 100
-        status_change_min_days: 10
+        status_change_min_days:
   - filename: telecom/log_level.yml
 --- 5,11 ----
   - filename: honeypot.yml
@@ -20,7 +20,7 @@ describe 'diff_process_settings' do
       honeypot:
 !       max_recording_seconds: 600
         answer_odds: 100
-        status_change_min_days: 10
+        status_change_min_days:
   - filename: telecom/log_level.yml
     EOS
   end
@@ -44,7 +44,7 @@ describe 'diff_process_settings' do
             honeypot:
       !       max_recording_seconds: 300
               answer_odds: 100
-              status_change_min_days: 10
+              status_change_min_days:
         - filename: telecom/log_level.yml
       --- 5,11 ----
         - filename: honeypot.yml
@@ -52,7 +52,7 @@ describe 'diff_process_settings' do
             honeypot:
       !       max_recording_seconds: 600
               answer_odds: 100
-              status_change_min_days: 10
+              status_change_min_days:
         - filename: telecom/log_level.yml
     EOS
   end

--- a/spec/bin/diff_process_settings_spec.rb
+++ b/spec/bin/diff_process_settings_spec.rb
@@ -12,7 +12,7 @@ describe 'diff_process_settings' do
       honeypot:
 !       max_recording_seconds: 300
         answer_odds: 100
-        status_change_min_days: null
+        status_change_min_days: 10
   - filename: telecom/log_level.yml
 --- 5,11 ----
   - filename: honeypot.yml
@@ -20,7 +20,7 @@ describe 'diff_process_settings' do
       honeypot:
 !       max_recording_seconds: 600
         answer_odds: 100
-        status_change_min_days: null
+        status_change_min_days: 10
   - filename: telecom/log_level.yml
     EOS
   end
@@ -44,7 +44,7 @@ describe 'diff_process_settings' do
             honeypot:
       !       max_recording_seconds: 300
               answer_odds: 100
-              status_change_min_days: null
+              status_change_min_days: 10
         - filename: telecom/log_level.yml
       --- 5,11 ----
         - filename: honeypot.yml
@@ -52,7 +52,7 @@ describe 'diff_process_settings' do
             honeypot:
       !       max_recording_seconds: 600
               answer_odds: 100
-              status_change_min_days: null
+              status_change_min_days: 10
         - filename: telecom/log_level.yml
     EOS
   end

--- a/spec/fixtures/production/combined_process_settings-16-0.yml
+++ b/spec/fixtures/production/combined_process_settings-16-0.yml
@@ -7,7 +7,7 @@
     honeypot:
       max_recording_seconds: 300
       answer_odds: 100
-      status_change_min_days: null
+      status_change_min_days: 10
 - filename: telecom/log_level.yml
   target:
     app: telecom

--- a/spec/fixtures/production/combined_process_settings-16-0.yml
+++ b/spec/fixtures/production/combined_process_settings-16-0.yml
@@ -7,7 +7,7 @@
     honeypot:
       max_recording_seconds: 300
       answer_odds: 100
-      status_change_min_days: 10
+      status_change_min_days:
 - filename: telecom/log_level.yml
   target:
     app: telecom

--- a/spec/fixtures/production/combined_process_settings-16-50.yml
+++ b/spec/fixtures/production/combined_process_settings-16-50.yml
@@ -7,7 +7,7 @@
     honeypot:
       max_recording_seconds: 300
       answer_odds: 100
-      status_change_min_days: null
+      status_change_min_days: 10
 - filename: telecom/log_level.yml
   target:
     app: telecom

--- a/spec/fixtures/production/combined_process_settings-16-50.yml
+++ b/spec/fixtures/production/combined_process_settings-16-50.yml
@@ -7,7 +7,7 @@
     honeypot:
       max_recording_seconds: 300
       answer_odds: 100
-      status_change_min_days: 10
+      status_change_min_days:
 - filename: telecom/log_level.yml
   target:
     app: telecom

--- a/spec/fixtures/production/combined_process_settings-16.yml
+++ b/spec/fixtures/production/combined_process_settings-16.yml
@@ -7,7 +7,7 @@
     honeypot:
       max_recording_seconds: 300
       answer_odds: 100
-      status_change_min_days: null
+      status_change_min_days: 10
 - filename: telecom/log_level.yml
   target:
     app: telecom

--- a/spec/fixtures/production/combined_process_settings-16.yml
+++ b/spec/fixtures/production/combined_process_settings-16.yml
@@ -7,7 +7,7 @@
     honeypot:
       max_recording_seconds: 300
       answer_odds: 100
-      status_change_min_days: 10
+      status_change_min_days:
 - filename: telecom/log_level.yml
   target:
     app: telecom

--- a/spec/fixtures/production/combined_process_settings-18-1.yml
+++ b/spec/fixtures/production/combined_process_settings-18-1.yml
@@ -7,7 +7,7 @@
     honeypot:
       max_recording_seconds: 600
       answer_odds: 100
-      status_change_min_days: 10
+      status_change_min_days:
 - filename: telecom/log_level.yml
   target:
     app: telecom

--- a/spec/fixtures/production/combined_process_settings-18-1.yml
+++ b/spec/fixtures/production/combined_process_settings-18-1.yml
@@ -7,7 +7,7 @@
     honeypot:
       max_recording_seconds: 600
       answer_odds: 100
-      status_change_min_days: null
+      status_change_min_days: 10
 - filename: telecom/log_level.yml
   target:
     app: telecom

--- a/spec/fixtures/production/combined_process_settings-18.yml
+++ b/spec/fixtures/production/combined_process_settings-18.yml
@@ -7,7 +7,7 @@
     honeypot:
       max_recording_seconds: 600
       answer_odds: 100
-      status_change_min_days: 10
+      status_change_min_days:
 - filename: telecom/log_level.yml
   target:
     app: telecom

--- a/spec/fixtures/production/combined_process_settings-18.yml
+++ b/spec/fixtures/production/combined_process_settings-18.yml
@@ -7,7 +7,7 @@
     honeypot:
       max_recording_seconds: 600
       answer_odds: 100
-      status_change_min_days: null
+      status_change_min_days: 10
 - filename: telecom/log_level.yml
   target:
     app: telecom

--- a/spec/fixtures/production/combined_process_settings-18b.yml
+++ b/spec/fixtures/production/combined_process_settings-18b.yml
@@ -7,7 +7,7 @@
     honeypot:
       max_recording_seconds: 600
       answer_odds: 200
-      status_change_min_days: null
+      status_change_min_days: 10
 - filename: telecom/log_level.yml
   target:
     app: telecom

--- a/spec/fixtures/production/combined_process_settings-18b.yml
+++ b/spec/fixtures/production/combined_process_settings-18b.yml
@@ -7,7 +7,7 @@
     honeypot:
       max_recording_seconds: 600
       answer_odds: 200
-      status_change_min_days: 10
+      status_change_min_days:
 - filename: telecom/log_level.yml
   target:
     app: telecom

--- a/spec/fixtures/production/combined_process_settings-19.yml
+++ b/spec/fixtures/production/combined_process_settings-19.yml
@@ -7,7 +7,7 @@
     honeypot:
       max_recording_seconds: 600
       answer_odds: 100
-      status_change_min_days: 10
+      status_change_min_days:
 - filename: telecom/log_level.yml
   target:
     app: telecom

--- a/spec/fixtures/production/combined_process_settings-19.yml
+++ b/spec/fixtures/production/combined_process_settings-19.yml
@@ -7,7 +7,7 @@
     honeypot:
       max_recording_seconds: 600
       answer_odds: 100
-      status_change_min_days: null
+      status_change_min_days: 10
 - filename: telecom/log_level.yml
   target:
     app: telecom

--- a/spec/fixtures/production/combined_process_settings.yml
+++ b/spec/fixtures/production/combined_process_settings.yml
@@ -7,7 +7,7 @@
     honeypot:
       max_recording_seconds: 600
       answer_odds: 100
-      status_change_min_days: 10
+      status_change_min_days:
 - filename: telecom/log_level.yml
   target:
     app: telecom

--- a/spec/fixtures/production/combined_process_settings.yml
+++ b/spec/fixtures/production/combined_process_settings.yml
@@ -7,7 +7,7 @@
     honeypot:
       max_recording_seconds: 600
       answer_odds: 100
-      status_change_min_days: null
+      status_change_min_days: 10
 - filename: telecom/log_level.yml
   target:
     app: telecom

--- a/spec/fixtures/production/settings/honeypot.yml
+++ b/spec/fixtures/production/settings/honeypot.yml
@@ -3,4 +3,4 @@ settings:
   honeypot:
     max_recording_seconds: 600
     answer_odds: 100
-    status_change_min_days: 10
+    status_change_min_days:

--- a/spec/fixtures/production/settings/honeypot.yml
+++ b/spec/fixtures/production/settings/honeypot.yml
@@ -3,4 +3,4 @@ settings:
   honeypot:
     max_recording_seconds: 600
     answer_odds: 100
-    status_change_min_days: null
+    status_change_min_days: 10

--- a/spec/lib/process_settings/testing/monitor_stub_spec.rb
+++ b/spec/lib/process_settings/testing/monitor_stub_spec.rb
@@ -10,7 +10,7 @@ describe ProcessSettings::Testing::MonitorStub do
                     honeypot:
                       max_recording_seconds: 300
                       answer_odds: 100
-                      status_change_min_days: 10
+                      status_change_min_days:
                   EOS
 
   subject do

--- a/spec/lib/process_settings/testing/monitor_stub_spec.rb
+++ b/spec/lib/process_settings/testing/monitor_stub_spec.rb
@@ -10,7 +10,7 @@ describe ProcessSettings::Testing::MonitorStub do
                     honeypot:
                       max_recording_seconds: 300
                       answer_odds: 100
-                      status_change_min_days: null
+                      status_change_min_days: 10
                   EOS
 
   subject do


### PR DESCRIPTION
## [0.13.1] - 2020-08-06
### Changed
- Removed explicit `: null` because `libyaml` 0.2.5 doesn't write the trailing space to key off.
Instead, explicitly depend on the `psych` gem and check that libyaml is at least 0.2.5.