### PR TITLE
No jira/fix minitest helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.3] - Unreleased
+### Fixed
+- Fixed `Testing::Helpers` for `minitest` to define a `teardown` method rather than call a `teardown` helper.
+
 ## [0.13.2] - 2020-08-07
 ### Fixed
 - Fixed typo in error message: "brew upgrade".
@@ -130,6 +134,8 @@ switching the script to use `Tempdir` for generating temporary file name
 - `ProcessSettings::Monitor.on_change` has been deprecated; it will be removed in version `1.0.0`.
   `ProcessSettings::Monitor.when_updated` should be used instead.
 
+[0.13.3]: https://github.com/Invoca/process_settings/compare/v0.13.2...v0.13.3
+[0.13.2]: https://github.com/Invoca/process_settings/compare/v0.13.1...v0.13.2
 [0.13.1]: https://github.com/Invoca/process_settings/compare/v0.12.0...v0.13.1
 [0.12.0]: https://github.com/Invoca/process_settings/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/Invoca/process_settings/compare/v0.10.5...v0.11.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    process_settings (0.13.2)
+    process_settings (0.13.3.pre.1)
       activesupport (>= 4.2, < 7)
       json
       listen (~> 3.0)

--- a/bin/combine_process_settings
+++ b/bin/combine_process_settings
@@ -77,11 +77,11 @@ end
 
 MINIMUM_LIBYAML_VERSION = '0.2.5' # So that null (nil) values don't have trailing spaces.
 
-def check_libyaml_version
+def warn_if_old_libyaml_version
   if Gem::Version.new(Psych::LIBYAML_VERSION) < Gem::Version.new(MINIMUM_LIBYAML_VERSION)
     warn <<~EOS
 
-      #{PROGRAM_NAME} error: libyaml version #{Psych::LIBYAML_VERSION} must be at least #{MINIMUM_LIBYAML_VERSION}. Try:
+      #{PROGRAM_NAME} warning: libyaml version #{Psych::LIBYAML_VERSION} is out of date; it should be at least #{MINIMUM_LIBYAML_VERSION}. On a Mac, try:
 
           brew update && brew upgrade libyaml
 
@@ -89,8 +89,6 @@ def check_libyaml_version
 
           gem install psych -- --enable-bundled-libyaml
     EOS
-
-    exit(1)
   end
 end
 
@@ -101,7 +99,7 @@ end
 
 options = parse_options(ARGV.dup)
 
-check_libyaml_version
+warn_if_old_libyaml_version
 
 combined_settings = read_and_combine_settings(Pathname.new(options.root_folder) + SETTINGS_FOLDER)
 

--- a/bin/combine_process_settings
+++ b/bin/combine_process_settings
@@ -106,7 +106,7 @@ combined_settings = read_and_combine_settings(Pathname.new(options.root_folder) 
 version_number = options.version || default_version_number(options.initial_filename)
 combined_settings << end_marker(version_number)
 
-yaml = combined_settings.to_yaml
+yaml = combined_settings.to_yaml.gsub(/: $/, ':') # libyaml before 0.2.5 wrote trailing space for nil
 yaml_with_warning_comment = add_warning_comment(yaml, options.root_folder, PROGRAM_NAME, SETTINGS_FOLDER)
 
 output_filename     = options.output_filename

--- a/lib/process_settings/testing/helpers.rb
+++ b/lib/process_settings/testing/helpers.rb
@@ -11,15 +11,14 @@ module ProcessSettings
     module Helpers
       class << self
         def included(including_klass)
-          after_method =
-            if including_klass.respond_to?(:teardown)
-              :teardown
-            else
-              :after
+          if including_klass.respond_to?(:after)  # rspec
+            including_klass.after do
+              ProcessSettings.instance = initial_instance
             end
-
-          including_klass.send(after_method) do
-            ProcessSettings.instance = initial_instance
+          else                                    # minitest
+            including_klass.define_method(:teardown) do
+              ProcessSettings.instance = initial_instance
+            end
           end
         end
       end

--- a/lib/process_settings/version.rb
+++ b/lib/process_settings/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ProcessSettings
-  VERSION = '0.13.2'
+  VERSION = '0.13.3.pre.1'
 end


### PR DESCRIPTION
## [0.13.3] - Unreleased
### Fixed
- Fixed `Testing::Helpers` for `minitest` to define a `teardown` method rather than call a `teardown` helper.

