### PR TITLE
no-jira: separate rspec from minitest helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - Unreleased
+### Added
+- Separated `ProcessSettings::Testing::Minitest::Helpers` from `ProcessSettings::Testing::RSpec::Helpers` since it is difficult
+to infer which is which. Left `ProcessSettings::Testing::Helpers` as an alias for `ProcessSettings::Testing::RSpec::Helpers` for
+backward-compatibility.
+
 ## [0.13.3] - 2020-08-11
 ### Fixed
 - Fixed `Testing::Helpers` for `minitest` to define a `teardown` method rather than call a `teardown` helper.
@@ -134,6 +140,7 @@ switching the script to use `Tempdir` for generating temporary file name
 - `ProcessSettings::Monitor.on_change` has been deprecated; it will be removed in version `1.0.0`.
   `ProcessSettings::Monitor.when_updated` should be used instead.
 
+[0.14.0]: https://github.com/Invoca/process_settings/compare/v0.13.3...v0.14.0
 [0.13.3]: https://github.com/Invoca/process_settings/compare/v0.13.2...v0.13.3
 [0.13.2]: https://github.com/Invoca/process_settings/compare/v0.13.1...v0.13.2
 [0.13.1]: https://github.com/Invoca/process_settings/compare/v0.12.0...v0.13.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    process_settings (0.13.3)
+    process_settings (0.14.0.pre.1)
       activesupport (>= 4.2, < 7)
       json
       listen (~> 3.0)

--- a/README.md
+++ b/README.md
@@ -169,8 +169,8 @@ The settings YAML files are always combined in alphabetical order by file path. 
 
 ### Testing
 For testing, it is often necessary to set a specific override hash for the process_settings values to use in
-that use case.  The `ProcessSettings::Testing::Helpers` module is provided for this purpose.  It can be used to
-override a specific hash of process settings, while leaving the rest intact, and resetting back to the defaults
+that use case.  The `ProcessSettings::Testing::RSpec::Helpers` and `ProcessSettings::Testing::Minitest::Helpers` modules are provided for this purpose.
+They can be used to override a specific hash of process settings, while leaving the rest intact, and resetting back to the defaults
 after the test case is over.  Here are some examples using various testing frameworks:
 
 #### RSpec
@@ -181,7 +181,7 @@ require 'process_settings/testing/helpers'
 RSpec.configure do |config|
   # ...
 
-  include ProcessSettings::Testing::Helpers
+  include ProcessSettings::Testing::RSpec::Helpers
 
   # Note: the include above will automatically register a global after block that will reset process_settings to their initial values.
   # ...
@@ -206,7 +206,7 @@ end
 require 'process_settings/testing/helpers'
 
 context SomeClass do
-  include ProcessSettings::Testing::Helpers
+  include ProcessSettings::Testing::Minitest::Helpers
 
   # Note: the include above will automatically register a teardown block that will reset process_settings to their initial values.
 

--- a/lib/process_settings/testing/helpers.rb
+++ b/lib/process_settings/testing/helpers.rb
@@ -8,47 +8,66 @@ require 'process_settings/testing/monitor'
 
 module ProcessSettings
   module Testing
-    module Helpers
-      class << self
-        def included(including_klass)
-          if including_klass.respond_to?(:after)  # rspec
+    module Base
+      module Helpers
+        # Adds the given settings_hash as an override at the end of the process_settings array, with default targeting (true).
+        # Therefore this will override these settings while leaving others alone.
+        #
+        # @param [Hash] settings_hash
+        #
+        # @return none
+        def stub_process_settings(settings_hash)
+          new_target_and_settings = ProcessSettings::TargetAndSettings.new(
+            '<test_override>',
+            Target::true_target,
+            ProcessSettings::Settings.new(settings_hash.deep_stringify_keys)
+          )
+
+          new_process_settings = [
+            *initial_instance.statically_targeted_settings,
+            new_target_and_settings
+          ]
+
+          ProcessSettings.instance = ProcessSettings::Testing::Monitor.new(
+            new_process_settings,
+            logger: initial_instance.logger
+          )
+        end
+
+        def initial_instance
+          @initial_instance ||= ProcessSettings.instance
+        end
+      end
+    end
+
+    module RSpec
+      module Helpers
+        include Base::Helpers
+
+        class << self
+          def included(including_klass)
             including_klass.after do
               ProcessSettings.instance = initial_instance
             end
-          else                                    # minitest
+          end
+        end
+      end
+    end
+
+    module Minitest
+      module Helpers
+        include Base::Helpers
+
+        class << self
+          def included(including_klass)
             including_klass.define_method(:teardown) do
               ProcessSettings.instance = initial_instance
             end
           end
         end
       end
-      # Adds the given settings_hash as an override at the end of the process_settings array, with default targeting (true).
-      # Therefore this will override these settings while leaving others alone.
-      #
-      # @param [Hash] settings_hash
-      #
-      # @return none
-      def stub_process_settings(settings_hash)
-        new_target_and_settings = ProcessSettings::TargetAndSettings.new(
-          '<test_override>',
-          Target::true_target,
-          ProcessSettings::Settings.new(settings_hash.deep_stringify_keys)
-        )
-
-        new_process_settings = [
-          *initial_instance.statically_targeted_settings,
-          new_target_and_settings
-        ]
-
-        ProcessSettings.instance = ProcessSettings::Testing::Monitor.new(
-          new_process_settings,
-          logger: initial_instance.logger
-        )
-      end
-
-      def initial_instance
-        @initial_instance ||= ProcessSettings.instance
-      end
     end
+
+    Helpers = RSpec::Helpers  # for backward-compatibility
   end
 end

--- a/lib/process_settings/version.rb
+++ b/lib/process_settings/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ProcessSettings
-  VERSION = '0.13.3'
+  VERSION = '0.14.0.pre.1'
 end

--- a/spec/lib/process_settings/testing/helpers_spec.rb
+++ b/spec/lib/process_settings/testing/helpers_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'process_settings/testing/helpers'
 
 describe ProcessSettings::Testing::Helpers do
-  class TestClassRSpec
+  class TestClassDefaultToRSpec
     @after_blocks = []
 
     class << self
@@ -22,6 +22,24 @@ describe ProcessSettings::Testing::Helpers do
     include ProcessSettings::Testing::Helpers
   end
 
+  class TestClassRSpec
+    @after_blocks = []
+
+    class << self
+      attr_reader :after_blocks
+
+      def after(&block)
+        after_blocks << block
+      end
+    end
+
+    def call_after_block
+      instance_exec(&self.class.after_blocks.first)
+    end
+
+    include ProcessSettings::Testing::RSpec::Helpers
+  end
+
   class TestClassMinitest
     class << self
       def after_blocks
@@ -33,7 +51,7 @@ describe ProcessSettings::Testing::Helpers do
       self.class.after_blocks.first.bind(self).call
     end
 
-    include ProcessSettings::Testing::Helpers
+    include ProcessSettings::Testing::Minitest::Helpers
   end
 
   let(:logger) { Logger.new('/dev/null') }
@@ -57,6 +75,12 @@ describe ProcessSettings::Testing::Helpers do
 
   describe 'when included in rspec' do
     let(:test_klass) { TestClassRSpec }
+
+    include_examples "defines after block"
+  end
+
+  describe 'when defaulted in rspec' do
+    let(:test_klass) { TestClassDefaultToRSpec }
 
     include_examples "defines after block"
   end


### PR DESCRIPTION
## [0.14.0] - Unreleased
### Added
- Separated `ProcessSettings::Testing::Minitest::Helpers` from `ProcessSettings::Testing::RSpec::Helpers` since it is difficult
to infer which is which. Left `ProcessSettings::Testing::Helpers` as an alias for `ProcessSettings::Testing::RSpec::Helpers` for
backward-compatibility.
