### PR TITLE
Fix typo in RSpec helper example

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ require 'process_settings/testing/helpers'
 RSpec.configure do |config|
   # ...
 
-  include ProcessSettings::Testing::RSpec::Helpers
+  config.include ProcessSettings::Testing::RSpec::Helpers
 
   # Note: the include above will automatically register a global after block that will reset process_settings to their initial values.
   # ...


### PR DESCRIPTION
### Summary of Changes

* Added the missing `config.` in the RSpec helper example code
