### PR TITLE
Update abstract monitor to not log info statements for cache read and write

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 /test/version_tmp/
 /tmp/
 
+# Editor files
+.idea/
+
 # Used by dotenv library to load environment variables.
 # .env
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2020-09-24
+### Changed
+- Changed the AbstractMonitor logging of cache hits and misses to debug level
+
 ## [0.15.1] - 2020-09-23
 ### Fixed
 - Fixed bug where if `make` output of combined_process_settings.yml was unchanged (ignoring version number),
@@ -152,6 +156,7 @@ switching the script to use `Tempdir` for generating temporary file name
 - `ProcessSettings::Monitor.on_change` has been deprecated; it will be removed in version `1.0.0`.
   `ProcessSettings::Monitor.when_updated` should be used instead.
 
+[0.16.0]: https://github.com/Invoca/process_settings/compare/v0.15.1...v0.16.0
 [0.15.1]: https://github.com/Invoca/process_settings/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/Invoca/process_settings/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/Invoca/process_settings/compare/v0.13.3...v0.14.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 
 ## [0.16.0] - 2020-09-24
 ### Changed
-- Changed the AbstractMonitor logging of cache hits and misses to debug level
+- Updated the AbstractMonitor to no longer log cache hits and misses
 
 ## [0.15.1] - 2020-09-23
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    process_settings (0.15.1)
+    process_settings (0.16.0)
       activesupport (>= 4.2, < 7)
       json
       listen (~> 3.0)

--- a/lib/process_settings/abstract_monitor.rb
+++ b/lib/process_settings/abstract_monitor.rb
@@ -133,15 +133,11 @@ module ProcessSettings
 
     def full_context_from_cache(dynamic_context)
       if (full_context = full_context_cache[dynamic_context])
-        logger.debug("cache hit ...")
         full_context
       else
-        logger.debug("cache miss ...")
         dynamic_context.deep_merge(static_context).tap do |full_context|
           if full_context_cache.size <= 1000
             full_context_cache[dynamic_context] = full_context
-          else
-            logger.debug("cache limit reached ...")
           end
         end
       end

--- a/lib/process_settings/abstract_monitor.rb
+++ b/lib/process_settings/abstract_monitor.rb
@@ -133,15 +133,15 @@ module ProcessSettings
 
     def full_context_from_cache(dynamic_context)
       if (full_context = full_context_cache[dynamic_context])
-        logger.info("cache hit ...")
+        logger.debug("cache hit ...")
         full_context
       else
-        logger.info("cache miss ...")
+        logger.debug("cache miss ...")
         dynamic_context.deep_merge(static_context).tap do |full_context|
           if full_context_cache.size <= 1000
             full_context_cache[dynamic_context] = full_context
           else
-            logger.info("cache limit reached ...")
+            logger.debug("cache limit reached ...")
           end
         end
       end

--- a/lib/process_settings/version.rb
+++ b/lib/process_settings/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ProcessSettings
-  VERSION = '0.15.1'
+  VERSION = '0.16.0'
 end


### PR DESCRIPTION
This is impacting consuming services that were not expecting additional logs at the `info` level.

### Summary of Changes
* Changed the `ProcessSettings::AbstractMonitor` to not log debugging statements for cache hits and miss
