### PR TITLE
Tech 4861 add restart after fork method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] - Unreleased
+### Added
+- Added `FileMonitor#restart_after_fork` to be used to restart the file monitoring after
+process forking occurs like with `unicorn`
+
 ## [0.16.0] - 2020-09-24
 ### Changed
 - Updated the AbstractMonitor to no longer log cache hits and misses
@@ -46,7 +51,7 @@ Instead, explicitly depend on the `psych` gem and check that libyaml is at least
 ### Changed
 - `bin/combine_process_settings` now uses an explicit `: null` value for null (nil in Ruby) values, vs.
 the former implicit `: ` at end of line. This is important because the trailing space was sometimes deleted
-when committed and pushed, depending on editor settings and git(hub) hook configuration. 
+when committed and pushed, depending on editor settings and git(hub) hook configuration.
 
 ## [0.11.0] - 2020-06-16
 ### Added
@@ -156,6 +161,7 @@ switching the script to use `Tempdir` for generating temporary file name
 - `ProcessSettings::Monitor.on_change` has been deprecated; it will be removed in version `1.0.0`.
   `ProcessSettings::Monitor.when_updated` should be used instead.
 
+[0.17.0]: https://github.com/Invoca/process_settings/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/Invoca/process_settings/compare/v0.15.1...v0.16.0
 [0.15.1]: https://github.com/Invoca/process_settings/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/Invoca/process_settings/compare/v0.14.0...v0.15.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    process_settings (0.16.0)
+    process_settings (0.17.0)
       activesupport (>= 4.2, < 7)
       json
       listen (~> 3.0)
@@ -10,7 +10,7 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (6.0.3.3)
+    activesupport (6.0.3.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)

--- a/README.md
+++ b/README.md
@@ -167,6 +167,19 @@ This will be applied in any process that has (`service_name == "frontend"` OR `s
 ### Precedence
 The settings YAML files are always combined in alphabetical order by file path. Later settings take precedence over the earlier ones.
 
+### Forked Processes
+When using `ProcessSettings` within an environment that is forking threads (like `unicorn` web servers), you can restart the `FileMonitor`
+after the fork with `restart_after_fork`.
+```ruby
+# unicorn.rb
+
+preload_app true
+
+after_fork do
+  ProcessSettings.instance.restart_after_fork
+end
+```
+
 ### Testing
 For testing, it is often necessary to set a specific override hash for the process_settings values to use in
 that use case.  The `ProcessSettings::Testing::RSpec::Helpers` and `ProcessSettings::Testing::Minitest::Helpers` modules are provided for this purpose.

--- a/lib/process_settings/file_monitor.rb
+++ b/lib/process_settings/file_monitor.rb
@@ -27,7 +27,11 @@ module ProcessSettings
     def start
       start_internal(enable_listen_thread?)
     end
-    deprecate :start, deprecator: ActiveSupport::Deprecation.new('1.0', 'ProcessSettings') # will become private
+    deprecate start: :restart_after_fork, deprecator: ActiveSupport::Deprecation.new('1.0', 'ProcessSettings')
+
+    def restart_after_fork
+      start_internal(enable_listen_thread?)
+    end
 
     def listen_thread_running?
       !@listener.nil?

--- a/lib/process_settings/version.rb
+++ b/lib/process_settings/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ProcessSettings
-  VERSION = '0.16.0'
+  VERSION = '0.17.0'
 end

--- a/spec/lib/process_settings/file_monitor_spec.rb
+++ b/spec/lib/process_settings/file_monitor_spec.rb
@@ -398,14 +398,14 @@ describe ProcessSettings::FileMonitor do
 
   describe "#restart_after_fork" do
     let(:monitor) { described_class.new(SETTINGS_PATH, logger: logger) }
-    subject { monitor.restart_after_fork}
+    subject { monitor.restart_after_fork }
 
     before do
       File.write(SETTINGS_PATH, EAST_SETTINGS_YAML)
       expect(monitor).to receive(:start_internal).with(true).and_return(true)
     end
 
-    after {FileUtils.rm_f(SETTINGS_PATH) }
+    after { FileUtils.rm_f(SETTINGS_PATH) }
 
     it { should eq(true) }
   end

--- a/spec/lib/process_settings/file_monitor_spec.rb
+++ b/spec/lib/process_settings/file_monitor_spec.rb
@@ -395,4 +395,18 @@ describe ProcessSettings::FileMonitor do
       expect(process_monitor.targeted_value('collective', dynamic_context: { 'region' => 'west', 'caller_id' => '+18887776666' }, required: false)).to eq(true)
     end
   end
+
+  describe "#restart_after_fork" do
+    let(:monitor) { described_class.new(SETTINGS_PATH, logger: logger) }
+    subject { monitor.restart_after_fork}
+
+    before do
+      File.write(SETTINGS_PATH, EAST_SETTINGS_YAML)
+      expect(monitor).to receive(:start_internal).with(true).and_return(true)
+    end
+
+    after {FileUtils.rm_f(SETTINGS_PATH) }
+
+    it { should eq(true) }
+  end
 end


### PR DESCRIPTION
Exposes a new method `restart_after_fork` that operates as `start` used to.
