### PR TITLE
No jira/use listen 3.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
-    listen (3.2.1)
+    listen (3.3.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     method_source (0.9.0)

--- a/lib/process_settings/monitor.rb
+++ b/lib/process_settings/monitor.rb
@@ -46,7 +46,7 @@ module ProcessSettings
       def logger=(new_logger)
         ActiveSupport::Deprecation.warn("ProcessSettings::Monitor.logger is deprecated and will be removed in v1.0.")
         @logger = new_logger
-        Listen.logger ||= new_logger
+        Listen.logger = new_logger unless Listen.instance_variable_get(:@logger)
       end
 
       deprecate :logger, :logger=, :file_path, :file_path=, deprecator: ActiveSupport::Deprecation.new('1.0', 'ProcessSettings')


### PR DESCRIPTION
### Summary of Changes
- Fix deprecated `ProcessSettings::Monitor.logger =` to work with `listen` v3.3.1.