### PR TITLE
Tech 14900 remove constant evaluation support from process settings gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.20.0] - Unreleased
+## [0.20.0-pre.is.0] - Unreleased
 ### Changed
 * Changed ProcessSettings to directly use `safe_load_file` method.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.0] - Unreleased
+### Changed
+* Changed ProcessSettings to directly use `safe_load_file` method.
+
 ## [0.19.4] - 2024-01-29
 ### Changed
 * Fix ProcessSettings::Testing::Minitest::Helpers to prepend #teardown instead of overriding it.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    process_settings (0.19.4)
+    process_settings (0.20.0.pre.pre.is.0)
       activesupport
       json
       listen (~> 3.0)
@@ -121,4 +121,4 @@ DEPENDENCIES
   simplecov-lcov
 
 BUNDLED WITH
-   2.3.10
+   2.4.19

--- a/lib/process_settings/targeted_settings.rb
+++ b/lib/process_settings/targeted_settings.rb
@@ -73,7 +73,7 @@ module ProcessSettings
       end
 
       def from_file(file_path, only_meta: false)
-        json_doc = Psych.load_file(file_path)
+        json_doc = Psych.safe_load_file(file_path)
         from_array(json_doc, only_meta: only_meta)
       end
     end

--- a/lib/process_settings/version.rb
+++ b/lib/process_settings/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ProcessSettings
-  VERSION = '0.19.4'
+  VERSION = '0.20.0'
 end

--- a/lib/process_settings/version.rb
+++ b/lib/process_settings/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ProcessSettings
-  VERSION = '0.20.0'
+  VERSION = '0.20.0-pre.is.0'
 end


### PR DESCRIPTION
## Remove constant evaluation support from YAML parsing

### Summary of Changes
* Changed ProcessSettings to directly use `safe_load_file` method.
