### PR TITLE
Fix Backstage catalog: add system: runtime-configuration

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -32,4 +32,5 @@ spec:
   type: library
   lifecycle: production
   owner: octothorpe
+  system: runtime-configuration
   dependsOn: []


### PR DESCRIPTION
## Summary

- Add `system: runtime-configuration` to catalog-info.yaml
